### PR TITLE
Enhancement: send metadata before and after data-streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ To be able to do the above three major classes are provided:
 
 ## Streaming Metadata
 
-When streaming data to the broker, following metadata is recorded through the `mfi-ddb` stream:
+When streaming data to the broker, the following metadata is recorded through the `mfi-ddb` stream:
 
 | Metadata | Description | Recorded as |
 |-------|-------------|-------------|
-| location context | The location context of the data being streamed, which includes the enterprise, site, area, and device. | [topic structure](#topic-structure) |
+| location context | The location context of the data being streamed, which includes the enterprise, site, area, and device. | [topic structure](./schema/README.md) |
 | attributes | Key-value pairs that provide additional information about the data being streamed. These are defined in the adapter yaml configuration file. | streamed on the same topic before data using the same topic family encoding |
 | streaming configuration | The configuration of the data stream, which includes broker information, enterprise and site details. | streamed on the `kv` and `blob` at birth and death of data streaming  |
 | adapter configuration | The configuration of the adapter that is streaming the data, which includes all the components and their attributes | streamed on the `kv` and `blob` at birth and death of data streaming |  

--- a/README.md
+++ b/README.md
@@ -73,3 +73,14 @@ To be able to do the above three major classes are provided:
 * [BlobTopicFamily](mfi_ddb/topic_families/blob.py)
 * [KeyValueTopicFamily](mfi_ddb/topic_families/key_value.py)
 * [SpbTopicFamily](mfi_ddb/topic_families/time_series_spb.py)
+
+## Streaming Metadata
+
+When streaming data to the broker, following metadata is recorded through the `mfi-ddb` stream:
+
+| Metadata | Description | Recorded as |
+|-------|-------------|-------------|
+| location context | The location context of the data being streamed, which includes the enterprise, site, area, and device. | [topic structure](#topic-structure) |
+| attributes | Key-value pairs that provide additional information about the data being streamed. These are defined in the adapter yaml configuration file. | streamed on the same topic before data using the same topic family encoding |
+| streaming configuration | The configuration of the data stream, which includes broker information, enterprise and site details. | streamed on the `kv` and `blob` at birth and death of data streaming  |
+| adapter configuration | The configuration of the adapter that is streaming the data, which includes all the components and their attributes | streamed on the `kv` and `blob` at birth and death of data streaming |  

--- a/mfi_ddb/data_adapters/mqtt.py
+++ b/mfi_ddb/data_adapters/mqtt.py
@@ -29,6 +29,8 @@ class _Mqtt:
         mqtt_port = int(mqtt_cfg['broker_port']) if 'broker_port' in mqtt_cfg.keys() else 1883
         mqtt_user = mqtt_cfg['username'] if 'username' in mqtt_cfg.keys() else None
         mqtt_pass = mqtt_cfg['password'] if 'password' in mqtt_cfg.keys() else None
+        if 'password' in mqtt_cfg.keys():
+            del self.mqtt_cfg['password']
         mqtt_tls_enabled = mqtt_cfg['tls_enabled'] if 'tls_enabled' in mqtt_cfg.keys() else False
         debug = mqtt_cfg['debug'] if 'debug' in mqtt_cfg.keys() else False
         

--- a/mfi_ddb/streamer/_mqtt.py
+++ b/mfi_ddb/streamer/_mqtt.py
@@ -101,7 +101,7 @@ class Mqtt:
             input_values = data[component_id]
             input_values = self._topic_family.process_data(input_values)
             if not bool(input_values):
-                print(f"Data not found for device {component_id}")
+                print(f"WARNING: Data not found for device {component_id}")
                 continue
             elif not self.__check_data(input_values):
                 raise Exception(f"{self._topic_family.topic_family_name} not compatible with Mqtt")
@@ -123,5 +123,11 @@ class Mqtt:
         
         for key in payload.keys():
             self.client.publish(f"{topic_prefix}/{key}", payload[key])
-        
-        print(f"Published data on topic: {topic_prefix}/{key}")
+            print(f"Published data on topic: {topic_prefix}/{key}")
+            
+    def set_death_payload(self, topic: str, payload: str, qos: int = 0, retain: bool = False):
+        """
+        Set the last will message for the MQTT client.
+        """
+        self.client.will_set(topic, payload, qos=qos, retain=retain)
+        print(f"Last will set for topic: {topic} with payload: {payload}")

--- a/mfi_ddb/streamer/_mqtt_spb.py
+++ b/mfi_ddb/streamer/_mqtt_spb.py
@@ -138,3 +138,6 @@ class MqttSpb:
                 if len(data[key]) > MAX_ARRAY_SIZE:
                     return False
         return True
+    
+    def set_death_payload(self, topic: str, payload: str, qos: int = 0, retain: bool = False):
+        raise NotImplementedError("Death payload is not implemented for MqttSpb")

--- a/mfi_ddb/streamer/_mqtt_spb.py
+++ b/mfi_ddb/streamer/_mqtt_spb.py
@@ -41,6 +41,9 @@ class MqttSpb:
         mqtt_port = int(mqtt_cfg['broker_port']) if 'broker_port' in mqtt_cfg.keys() else 1883
         mqtt_user = mqtt_cfg['username'] if 'username' in mqtt_cfg.keys() else None
         mqtt_pass = mqtt_cfg['password'] if 'password' in mqtt_cfg.keys() else None
+        if 'password' in mqtt_cfg.keys():
+            del self.cfg['mqtt']['password']  # Remove password from config for security reasons
+                    
         mqtt_tls_enabled = mqtt_cfg['tls_enabled'] if 'tls_enabled' in mqtt_cfg.keys() else False
         debug = mqtt_cfg['debug'] if 'debug' in mqtt_cfg.keys() else False
         

--- a/mfi_ddb/streamer/streamer.py
+++ b/mfi_ddb/streamer/streamer.py
@@ -1,14 +1,18 @@
+import os
+import platform
+import socket
 import time
+from datetime import datetime
 
 import paho.mqtt.client as paho_mqtt
-from .observer import Observer
-
 from mfi_ddb.data_adapters import *
 from mfi_ddb.topic_families import *
 from mfi_ddb.utils.exceptions import ConfigError
+from mfi_ddb.utils.script_utils import *
 
 from ._mqtt import Mqtt
 from ._mqtt_spb import MqttSpb
+from .observer import Observer
 
 TOPIC_CLIENTS = {
     "historian": ("MqttSpb", "HistorianTopicFamily"),
@@ -20,6 +24,9 @@ class Streamer(Observer):
     def __init__(self, config: dict, data_adp: BaseDataAdapter, stream_on_update:bool = False) -> None:
         super().__init__()
         
+        
+        # 1. initialize the data adapter and respective topic family client
+        # `````````````````````````````````````````````````````````````````````````
         self.cfg = config
         topic_family_name = config['topic_family']
         
@@ -28,12 +35,37 @@ class Streamer(Observer):
         
         topic_family = globals()[TOPIC_CLIENTS[topic_family_name][1]]()
         self.__client = globals()[TOPIC_CLIENTS[topic_family_name][0]](config, topic_family)
-        
-        self.__data_adp = data_adp
-        
+        self.__data_adp = data_adp        
         self.__client.connect(data_adp.component_ids)
-        
         self.__data_adp.get_data()
+        
+        # 2. initialize the key-value metadata and respective topic family client
+        # `````````````````````````````````````````````````````````````````````````
+        trial_id = str(self.__data_adp.cfg.get('trial_id', None))
+        kv_topic_family = globals()[TOPIC_CLIENTS['kv'][1]]()
+        blob_topic_family = globals()[TOPIC_CLIENTS['blob'][1]]()
+        kv_client = globals()[TOPIC_CLIENTS['kv'][0]](config, kv_topic_family)
+        blob_client = globals()[TOPIC_CLIENTS['blob'][0]](config, blob_topic_family)
+        
+        kv_client.connect(['birth_metadata', 'death_metadata'])
+        blob_client.connect(['birth_metadata', 'death_metadata'])
+        kv_payload = self.__generate_birth_kv_payload(self.__data_adp)
+        blob_birth_payload = get_blob_json_payload_from_dict(data = kv_payload,
+                                                             file_name = f'{trial_id}_metadata_birth.json',
+                                                             trial_id = trial_id)
+        blob_death_payload = get_blob_json_payload_from_dict(data = kv_payload,
+                                                             file_name = f'{trial_id}_metadata_death.json',
+                                                             trial_id = trial_id)        
+        
+        # 3. publish the key-value metadata birth message with initial data
+        # `````````````````````````````````````````````````````````````````````````
+        kv_client.stream_data({"birth_metadata": kv_payload})
+        kv_client.set_death_payload("death_metadata", {"death_metadata": kv_payload})
+        blob_client.stream_data({"birth_metadata": blob_birth_payload})
+        blob_client.set_death_payload("death_metadata", {"death_metadata": blob_death_payload})
+        
+        # 4. publish the birth message of the data adapter        
+        # `````````````````````````````````````````````````````````````````````````
         self.__client.publish_birth(self.__data_adp.attributes, self.__data_adp.data)
         self.__data_adp.clear_data_buffer()
         
@@ -71,3 +103,25 @@ class Streamer(Observer):
     def stream_data(self):
         self.__client.stream_data(self.__data_adp.data)
         self.__data_adp.clear_data_buffer()
+        
+    def __generate_birth_kv_payload(self, data_adp: BaseDataAdapter) -> dict:
+        
+        payload = {
+            "time": {
+                "birth": datetime.now().isoformat()
+                },
+            "source": {
+                "os": platform.system(),
+                "hostname": socket.gethostname(),
+                "fqdn": socket.getfqdn(),
+            },
+            "adapter": {
+                "config": self.__data_adp.cfg,
+                "component_ids": self.__data_adp.component_ids,
+                "attributes": self.__data_adp.attributes,
+                "sample_data": self.__data_adp.data,
+            },
+            "broker": self.cfg            
+        }         
+        
+        return payload

--- a/mfi_ddb/streamer/streamer.py
+++ b/mfi_ddb/streamer/streamer.py
@@ -56,14 +56,14 @@ class Streamer(Observer):
         blob_death_payload = get_blob_json_payload_from_dict(data = kv_payload,
                                                              file_name = f'{trial_id}_metadata_death.json',
                                                              trial_id = trial_id)        
-        
+
         # 3. publish the key-value metadata birth message with initial data
         # `````````````````````````````````````````````````````````````````````````
         kv_client.stream_data({"birth_metadata": kv_payload})
-        kv_client.set_death_payload("death_metadata", {"death_metadata": kv_payload})
+        kv_client.set_death_payload("death_metadata", kv_payload)
         blob_client.stream_data({"birth_metadata": blob_birth_payload})
-        blob_client.set_death_payload("death_metadata", {"death_metadata": blob_death_payload})
-        
+        blob_client.set_death_payload("death_metadata", blob_death_payload)
+
         # 4. publish the birth message of the data adapter        
         # `````````````````````````````````````````````````````````````````````````
         self.__client.publish_birth(self.__data_adp.attributes, self.__data_adp.data)

--- a/mfi_ddb/topic_families/key_value.py
+++ b/mfi_ddb/topic_families/key_value.py
@@ -1,6 +1,24 @@
 from .base import BaseTopicFamily
+import json
 
 class KeyValueTopicFamily(BaseTopicFamily):
     def __init__(self):
         super().__init__()
         self.topic_family_name = "kv"
+        
+    def process_data(self, data):
+        for key in data.keys():
+            data[key] = self.__autotype(data[key])
+            
+        return data
+    
+    def __autotype(self, data):
+        if not isinstance(data, dict):
+            for cast in (int, float, str):
+                try:
+                    return cast(data)
+                except:
+                    continue
+        else:
+            data = json.dumps(data)
+            return data        

--- a/mfi_ddb/utils/script_utils.py
+++ b/mfi_ddb/utils/script_utils.py
@@ -1,4 +1,5 @@
-
+import json
+import time
 
 def get_topic_from_config(cfg: dict) -> str:
     """
@@ -18,3 +19,29 @@ def get_topic_from_config(cfg: dict) -> str:
         NotImplementedError("Topic for historian is not implemented yet")
         
     return f"{topic}/#"
+
+def get_blob_json_payload_from_dict(data: dict, file_name: str, trial_id:str) -> dict:
+    """
+    Convert a dictionary to a JSON payload for blob data.
+    """
+    if not isinstance(data, dict):
+        raise TypeError("Data must be a dictionary")
+    
+    json_data = json.dumps(data, indent=4)
+    json_bytes = json_data.encode('utf-8')
+    
+    payload = {
+        "file_name": file_name,
+        "file_type": '.json',
+        "size": json_bytes.__sizeof__(),
+        "timestamp": int(time.time()),
+        "file": json_bytes,
+        "trial_id": trial_id if trial_id else "",
+    }
+    
+    # Add other metadata
+    for key, value in data.items():
+        if key not in ["file_name", "file_type", "size", "timestamp", "file"]:
+            payload[key] = value
+            
+    return payload

--- a/mfi_ddb/utils/script_utils.py
+++ b/mfi_ddb/utils/script_utils.py
@@ -38,10 +38,5 @@ def get_blob_json_payload_from_dict(data: dict, file_name: str, trial_id:str) ->
         "file": json_bytes,
         "trial_id": trial_id if trial_id else "",
     }
-    
-    # Add other metadata
-    for key, value in data.items():
-        if key not in ["file_name", "file_type", "size", "timestamp", "file"]:
-            payload[key] = value
-            
+                
     return payload

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ paho-mqtt
 watchdog
 protobuf
 numpy
+opencv-python
+open3d

--- a/schema/README.md
+++ b/schema/README.md
@@ -70,3 +70,14 @@ blob topic tree expects large binary files.
 * The schema is designed to be flexible and extensible to accommodate different types of data. 
 * The schema is defined in [kv.json](./kv.json).
 * While [blob](#blob-binary-data) and [historian](#historian-time-series) are protobuf serialized, k-v messages are sent as json for ease of readability.
+
+## Streaming Metadata
+
+When streaming data to the broker, following metadata is recorded through the `mfi-ddb` stream:
+
+| Metadata | Description | Recorded as |
+|-------|-------------|-------------|
+| location context | The location context of the data being streamed, which includes the enterprise, site, area, and device. | [topic structure](#topic-structure) |
+| attributes | Key-value pairs that provide additional information about the data being streamed. These are defined in the adapter yaml configuration file. | streamed on the same topic before data using the same topic family encoding |
+| streaming configuration | The configuration of the data stream, which includes broker information, enterprise and site details. | streamed on the `kv` and `blob` at birth and death of data streaming  |
+| adapter configuration | The configuration of the adapter that is streaming the data, which includes all the components and their attributes | streamed on the `kv` and `blob` at birth and death of data streaming |  

--- a/schema/README.md
+++ b/schema/README.md
@@ -73,7 +73,7 @@ blob topic tree expects large binary files.
 
 ## Streaming Metadata
 
-When streaming data to the broker, following metadata is recorded through the `mfi-ddb` stream:
+When streaming data to the broker, the following metadata is recorded through the `mfi-ddb` stream:
 
 | Metadata | Description | Recorded as |
 |-------|-------------|-------------|

--- a/scripts/test_mqtt_lwt.py
+++ b/scripts/test_mqtt_lwt.py
@@ -1,0 +1,24 @@
+import paho.mqtt.client as mqtt
+import time
+
+def on_connect(client, userdata, flags, rc):
+    print(f"Connected with result code {rc}")
+
+client = mqtt.Client()
+
+def main():
+    client.on_connect = on_connect
+
+    # Set the Last Will and Testament
+    client.will_set("mfi-v1.0-kv/test", payload="My client has died!", qos=1, retain=False)
+
+    # Set a short keep-alive of 5 seconds
+    client.username_pw_set("admin", "CMUmfi2024!")
+    client.connect("172.26.179.142", 1883, 5)
+
+    client.loop_start()
+
+
+main()
+while True:
+    time.sleep(1)


### PR DESCRIPTION
**Type**: Enhancement

**Brief Description**

> Provide a short, 2-line description of the contribution.

Compile metadata for the data-streaming as key-value payload (for kv stream), and JSON file (for blob stream). Send respective payloads as the birth message, and stage them as "last will" death message [[1]](https://www.emqx.com/en/blog/use-of-mqtt-will-message) [[2]](https://docs.emqx.com/en/emqx/latest/messaging/mqtt-will-message.html).

**Testing**

> describe existing state (e.g., current console output, results, etc.).

* Types of metadata explained in `README.md` and `schema/README.md`
* Before this PR, only first two metadata were streamed, i.e., `location context` and `attributes`

> steps to verify the enhancement (how to run the new code and observe the improvement).

* This PR allows adding redundant metadata stream on `kv` and `blob` topic trees.
* Try any `stream_*.py` file in examples/
* Example birth and death messages streamed: [birth.json](https://github.com/user-attachments/files/20718332/birth.json), [death.json](https://github.com/user-attachments/files/20718331/death.json)


> reference relevant README files to understand the new utility

* Metadata details added in `README.md` and `schema/README.md`

**Minor Enhancement(s)**
* Changed requirements.txt file to include opencv and open3d

**Potential failure points**

> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* The changes required some changes in Streamer, Mqtt, and MqttSpb classes. Some minor change might cause the adapter streaming to break.
* Only tested with `stream_mqtt.py` example. It might result in oversight of some metadata information relevant to other adapters that could be combined.
* Metadata through `blob` is sent via `..../metadata/data` topic, and metadata through `kv` is sent via `..../metadata/birth` and `.../metadata/death`. It might be confusing if not properly defined.

**Potential improvement**

> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* The death payload should have the time of death. Since the death payload is sent to the broker at the time of connection, I am not sure how to define that value. We can get some clues from the `mqtt_spb_wrapper` repo, which sends a death message and a timestamp.