### PR TITLE
🐞 Bug Fix: stream_mtconnect.py example not working with HAAS-UMC750

### DIFF
--- a/mfi_ddb/streamer/streamer.py
+++ b/mfi_ddb/streamer/streamer.py
@@ -1,5 +1,7 @@
 import json
 import os
+import copy
+import sys
 import platform
 import socket
 import time
@@ -29,14 +31,14 @@ class Streamer(Observer):
         
         # 1. initialize the data adapter and respective topic family client
         # `````````````````````````````````````````````````````````````````````````
-        self.cfg = config
+        self.cfg = copy.deepcopy(config)
         topic_family_name = config['topic_family']
         
         if topic_family_name not in TOPIC_CLIENTS:
             raise ConfigError(f"Invalid topic family: {topic_family_name}")
         
         topic_family = globals()[TOPIC_CLIENTS[topic_family_name][1]]()
-        self.__client = globals()[TOPIC_CLIENTS[topic_family_name][0]](config, topic_family)
+        self.__client = globals()[TOPIC_CLIENTS[topic_family_name][0]](self.cfg, topic_family)
         self.__data_adp = data_adp        
         self.__client.connect(data_adp.component_ids)
         self.__data_adp.get_data()
@@ -46,9 +48,9 @@ class Streamer(Observer):
         trial_id = str(self.__data_adp.cfg.get('trial_id', None))
         kv_topic_family = globals()[TOPIC_CLIENTS['kv'][1]]()
         blob_topic_family = globals()[TOPIC_CLIENTS['blob'][1]]()
-        kv_client = globals()[TOPIC_CLIENTS['kv'][0]](config, kv_topic_family)
-        blob_client = globals()[TOPIC_CLIENTS['blob'][0]](config, blob_topic_family)
-        
+        kv_client = globals()[TOPIC_CLIENTS['kv'][0]](copy.deepcopy(config), kv_topic_family)
+        blob_client = globals()[TOPIC_CLIENTS['blob'][0]](copy.deepcopy(config), blob_topic_family)
+
         kv_payload = self.__generate_birth_kv_payload(self.__data_adp)
         blob_birth_payload = get_blob_json_payload_from_dict(data = kv_payload,
                                                              file_name = f'{trial_id}_metadata_birth.json',
@@ -111,6 +113,17 @@ class Streamer(Observer):
         
     def __generate_birth_kv_payload(self, data_adp: BaseDataAdapter) -> dict:
         
+        sample_data = copy.deepcopy(self.__data_adp.data)
+        sample_data_size = sys.getsizeof(str(sample_data))
+        
+        # drop keys until the size is less than 32768 bytes
+        # since total size of payload <= 65536 bytes
+        # ref: error with paho-mqtt: "struct.error: 'H' format requires 0 <= number <= 65535"
+        while sample_data_size > 32768:
+            # remove the last key
+            sample_data.popitem()
+            sample_data_size = sys.getsizeof(str(sample_data))
+        
         payload = {
             "time": {
                 "birth": datetime.now().isoformat()
@@ -124,7 +137,7 @@ class Streamer(Observer):
                 "config": self.__data_adp.cfg,
                 "component_ids": self.__data_adp.component_ids,
                 "attributes": self.__data_adp.attributes,
-                "sample_data": self.__data_adp.data,
+                "sample_data": sample_data,
             },
             "broker": self.__client.cfg            
         }         


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

 With PR #14, we introduced a feature to send metadata on `kv` and `blob` topic streams at the birth and death of data streaming. JSON string death payload on `kv` topic stream was >65536 bytes with HAAS-UMC750, and `paho-mqtt` errors out.

### Details

* When running the following two lines, the program errors out on the second line due to death payload size
```
kv_client.set_death_payload("metadata", {'death': kv_payload})
kv_client.connect(['metadata'])
```
* Error: `struct.error: 'H' format requires 0 <= number <= 65535`

**THE FIX**
  * Edited `mfi_ddb/streamer/streamer.py` > Streamer > __generate_birth_kv_payload
  * Dropping keys in sample data until the sample data is <32768 (i.e., 65536/2), giving enough margin for the rest of the data in the death payload.

* **additional details**
  * With PR #14, we also made sure that the broker password was not kept in config after connection (reference commit cc8f3e0)
  * Since multiple clients are using that config, it caused an issue with `kv`/`blob` client not connecting
  * Fixed it by using `copy.deepcopy()` in the Streamer __init__ method.

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* The code currently uses a hard-coded value of `32768`
* Important sample data key doesn't stream, making it harder to track data.
* Some sample data, which might have been fine being over 32768, and still have total death payload <65535, will have a few keys trimmed.


### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* The issue is only with the death payload, so we can skip the sample data in the death payload, but test if keeping it in the birth message still works.