### PR TITLE
🐞 Bug Fix: Issue #21

### DIFF
--- a/mfi_ddb/data_adapters/mtconnect.py
+++ b/mfi_ddb/data_adapters/mtconnect.py
@@ -64,8 +64,10 @@ class MTconnectDataAdapter(BaseDataAdapter):
                     
     def get_data(self):
         raw_data = self.__request_agent('current')
-
-        component_stream = raw_data.MTConnectStreams.Streams.DeviceStream.ComponentStream
+        devices = raw_data.MTConnectStreams.Streams.DeviceStream
+        device = devices[0] if isinstance(devices, omegaconf.listconfig.ListConfig) else devices
+        
+        component_stream = device.ComponentStream
         if not isinstance(component_stream, omegaconf.listconfig.ListConfig):
             component_stream = [component_stream]
             
@@ -73,8 +75,10 @@ class MTconnectDataAdapter(BaseDataAdapter):
     
     def update_data(self):
         raw_data = self.__request_agent('sample')
+        devices = raw_data.MTConnectStreams.Streams.DeviceStream
+        device = devices[0] if isinstance(devices, omegaconf.listconfig.ListConfig) else devices
         
-        component_stream = raw_data.MTConnectStreams.Streams.DeviceStream.ComponentStream
+        component_stream = device.ComponentStream
         if not isinstance(component_stream, omegaconf.listconfig.ListConfig):
             component_stream = [component_stream]
         


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

MTConnectDataAdapter cannot handle streaming from an MTConnect agent with multiple devices. Fixed the issue by picking the first device in the `current` streaming.

### Details

* In Issue #21, the user connects to 'http://agent.mtconnect.org/' 
* It has 8 devices connect to the same agent
* Adapter is not designed currently to handle multiple devices

* **steps to reproduce the bug**
  * Use `stream_mtconnect.py` example with config defined in Issue #21 

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* MTConnect stream may not have the same order of devices in `current` and `sample`. See, for instance, 'http://agent.mtconnect.org/current' and 'http://agent.mtconnect.org/sample'

### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* Choose `uuid` during initialization, instead of the first device.
* Include an optional config parameter in data adapter config to allow a user to choose the device uuid from the mtconnect stream.