### PR TITLE
🐞Bug fix: issue #22

### DIFF
--- a/mfi_ddb/utils/script_utils.py
+++ b/mfi_ddb/utils/script_utils.py
@@ -26,7 +26,17 @@ def get_blob_json_payload_from_dict(data: dict, file_name: str, trial_id:str) ->
     """
     if not isinstance(data, dict):
         raise TypeError("Data must be a dictionary")
-    
+
+    # check if any value was bytes type
+    def drop_bytes_values(d: dict) -> dict:
+        for key, value in list(d.items()):
+            if isinstance(value, bytes):
+                del d[key]
+            elif isinstance(value, dict):
+                drop_bytes_values(value)
+        return d
+
+    data = drop_bytes_values(data)
     json_data = json.dumps(data, indent=4)
     json_bytes = json_data.encode('utf-8')
     


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

Cannot stream a file as sample data as birth message (PR #14) since bytes value is not JSON serializable. Fixed that by removing any key with bytes type data at birth.

### Details

* Fixed method `get_blob_json_payload_from_dict` in `script_utils` to drop bytes value(s)
* Issue exists only when streaming from an adapter with bytes data value, like LocalFilesDataAdapter
* As described in Issue #22, the error occurs from line 61 in __init__ method. So, `blob_birth_payload` and `blob_death_payload` needs a JSON data

* **steps to reproduce the bug**
  * Details in issue #22 

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* The recursive `drop_bytes_values` doesn't consider a case of a list of bytes value, which is unlikely in our application
* In __init__ method of Streamer, interestingly `kv_payload` can have bytes value which gets filtered out before sending by the paho_mqtt library. So, if that changes in paho_mqtt library, the application may error out.

### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* Issue #22, and PR #23, are both due to insufficient testing of PR #14. Implement unit test for the Streamer class since so that any new enhancements added to core mfi_ddb are run through those tests without breaking exisiting working code.