### PR TITLE
🐞Bug fix: issue #18

### DIFF
--- a/mfi_ddb/streamer/_mqtt.py
+++ b/mfi_ddb/streamer/_mqtt.py
@@ -70,12 +70,12 @@ class Mqtt:
         # LAST WILL AND TESTAMENT
         self.__set_last_will()        
 
-        self.client.connect(mqtt_host, mqtt_port, 5)
-        
+        self.client.connect(mqtt_host, mqtt_port, 300)
+        self.client.loop_start()
+
         while not self.client.is_connected():
             print("Connecting to MQTT broker...")
             time.sleep(1)
-            self.client.loop_start()
 
         self._components = component_ids
         

--- a/mfi_ddb/streamer/_mqtt.py
+++ b/mfi_ddb/streamer/_mqtt.py
@@ -70,7 +70,7 @@ class Mqtt:
         # LAST WILL AND TESTAMENT
         self.__set_last_will()        
 
-        self.client.connect(mqtt_host, mqtt_port, 300)
+        self.client.connect(mqtt_host, mqtt_port, 60)
         self.client.loop_start()
 
         while not self.client.is_connected():


### PR DESCRIPTION
## 🛠️ Brief Description

After some time, it seemed the connection to MQTT was timing out.  Fixed the issue by updating two lines related to keep-alive and the MQTT loop to ensure the connection stays active.

## 🔍 Details

1. `self.client.connect(mqtt_host, mqtt_port, 300)`  
   - The third argument is the **keepalive** value.
   - Previously it was set to `5`, which caused the broker to disconnect the client quickly if no data or heartbeat was sent.

2. `self.client.loop_start()`  
   - This must be called only once, outside any loop.
   - It's a thread that runs forever, so calling it multiple times causes threading errors.

[Paho Documentation](https://eclipse.dev/paho/files/paho.mqtt.python/html/client.html#paho.mqtt.client.Client.loop_start)  
> This is part of the threaded client interface. Call this once to start a new thread to process network traffic.  
> This provides an alternative to repeatedly calling `loop()` yourself.  
> Under the hood, this will call `loop_forever()` in a thread, which means that the thread will terminate if you call `disconnect()`.

## 🐞 Steps to Reproduce the Bug

1. Start streaming.
2. Wait ~10 minutes.
3. Try to send another file.

You will see in your MQTT broker (e.g., EMQX Dashboard) that the client is not longer an active connection.
No new data is received on the subscribed topic.

---

## ⚠️ Potential Failure Points

- The `disconnect()` method is not fully implemented.
- This may lead to unclean disconnects, potential memory leaks, or stale sessions on the broker.

---

## 💡 Potential Improvement

- Check if `_mqtt_spb.py` needs the **same updates** to `connect()` and `loop_start()` handling.

---

🔗 **Issue:** [cmu-mfi/mfi_ddb_library#18](https://github.com/cmu-mfi/mfi_ddb_library/issues/18)
