### PR TITLE
Bug Fix: mqtt_spb truncate string values

### DIFF
--- a/mfi_ddb/streamer/_mqtt_spb.py
+++ b/mfi_ddb/streamer/_mqtt_spb.py
@@ -8,6 +8,7 @@ from mfi_ddb.topic_families.base import BaseTopicFamily
 from mfi_ddb.utils.exceptions import ConfigError
 
 MAX_ARRAY_SIZE = 16
+MAX_STRING_LENGTH = 255
 
 class MqttSpb:
     def __init__(self, config: dict, topic_family: BaseTopicFamily) -> None:
@@ -140,6 +141,9 @@ class MqttSpb:
             if type(data[key]) == list:
                 if len(data[key]) > MAX_ARRAY_SIZE:
                     return False
+            if type(data[key]) == str:
+                if len(data[key]) > 255:
+                    data[key] = data[key][:255]  # Truncate string to 255 characters
         return True
     
     def set_death_payload(self, topic: str, payload: str, qos: int = 0, retain: bool = False):


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

Some MTConnect agents, like HAAS, stream long string values for a key delimited by commas. While the sparkplug protocol can send that payload through the MQTT broker, not all data historians, such as AVEVA PI, can ingest long strings.

### Details

* Below is the error in AVEVA PI historian
```
I Data server: pgh-acdpi-01.andrew.ad.cmu.edu | PI Event Queue - An 
error occurred for the following PI events: Error: [-11009] Event 
Contents Are Too Big to Fit in Any Record PointID: 63430; TimeStamp: 
16-Jul-2025 15:19:28.11000Z (Utc); Value: 
0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,90.0,270.0,0.0,0.0,-19.
4224,-10.1274,-18.7213,0.0,0 ......
```
* Edited `_mqtt_spb.py` to truncate string value before streaming.

* **steps to reproduce the bug**
  * Pre-requisite: 
    * Aveva PI Historian configured with MQTT sparkplug connector, and listening to the `mfi-v1.0-historian/#` topic, 
    * HAAS UMC 750 with MTconnect agent
    * Edge device with mfi_ddb_library installed
  * Run the `stream_mtconnect.py` example with the right configurations.
  * Check the connector logs in the historian

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* The current fix limits all adapters to stream long string values on `mfi-v1.0-historian/#`
* Some other adapter that relies on sparkplug message streaming may have unforeseen errors due to this bug fix.
* The bug fix hasn't been tested on other time-series sparkplug adapters. 

### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* Current string truncation is at 255 characters. Check AVEVA PI for the string value limit, so that we can increase the value.
* Convert the comma-delimited values to a list, and stream as a list. Check AVEVA PI for the max list size ingestion, if any.