### PR TITLE
🐞 Bug Fix: issue #17 - handling multiple subscriptions

### DIFF
--- a/mfi_ddb/data_adapters/mqtt.py
+++ b/mfi_ddb/data_adapters/mqtt.py
@@ -116,10 +116,8 @@ class MqttDataAdapter(BaseDataAdapter, _Mqtt):
 
         # extract key to store the message in the data dictionary
         data = {}
-        try:
-            subscription_topic = self.attributes[component_id]['topic']
-        except KeyError:
-            breakpoint()
+        subscription_topic = self.attributes[component_id]['topic']
+
         if subscription_topic.split('/')[-1] == '#':
             # If the topic ends with '#', it means we are subscribing to all subtopics
             # We need to extract the subtopic from the received topic


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

The adapter class was not able to initialize data for multiple "components" due to the failure to map topics to the right "components". One of the primary contributions in this PR is to identify the right "component" when a topic message is received.

### Details

* Earlier the program was stuck on the following message in the terminal logs. (file: `streamer.py`, line: 47)
```
WARNING: Waiting for birth data to be populated in the data adapter for all components...
```
* This is because the data was not being populated and was being overwritten on the last component on the list
* Fixed the error by adding and using a utility function in the MqttDataAdapter class, `__get_component_from_topic`
* Additionally, the adapter was not extracting values from multiple keys. So, fixed the recursive function `__extract_key_value`

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* The regex pattern matching in the method `__get_component_from_topic` might not consider some cases. This can be identified if the terminal logs give an exception message of `ERROR in file ... line .... Please raise an issue with the development team.`
* Didn't test it on the polling-based streaming.
* Supports only JSON or primitive values (string, float, int...)


### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* It will be nice if the lambda function in line 94 can allow passing the component id so that we can skip deciphering the right component id inside `_topic_callback` (line 114).
