### PR TITLE
🌟 Enhancement: Added `SELF_UPDATE` property to all data adapters and LocalFilesDataAdapter tracks modifications

### DIFF
--- a/mfi_ddb/data_adapters/base.py
+++ b/mfi_ddb/data_adapters/base.py
@@ -12,6 +12,7 @@ class BaseDataAdapter:
     CONFIG_EXAMPLE = None
     CONFIG_HELP = None
     RECOMMENDED_TOPIC_FAMILY = None
+    SELF_UPDATE = False  # If True, the data adapter will update the data by itself in a separate thread.
 
     class SCHEMA(BaseModel):
         """

--- a/mfi_ddb/data_adapters/local_files.py
+++ b/mfi_ddb/data_adapters/local_files.py
@@ -45,6 +45,8 @@ class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
     
     RECOMMENDED_TOPIC_FAMILY = "blob"
     
+    SELF_UPDATE = True  # This data adapter will update the data by itself in a separate thread.
+    
     class _SystemInfo(BaseModel):
         trial_id: str = Field(..., description="Trial ID for the system. No spaces or special characters allowed.")
         name: str = Field(..., description="Name of the system.")

--- a/mfi_ddb/data_adapters/local_files.py
+++ b/mfi_ddb/data_adapters/local_files.py
@@ -8,7 +8,7 @@ from typing import List
 import numpy as np
 import yaml
 from pydantic import BaseModel, Field
-from watchdog.events import FileSystemEventHandler
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
 from mfi_ddb.data_adapters.base import BaseDataAdapter
@@ -92,9 +92,9 @@ class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
         if len(self.buffer_data) > 0:
             data = self.buffer_data.pop(0)
             self._data[self.system_name] = data
-            return        
-                    
-    def on_created(self, event):
+            return
+
+    def on_created(self, event: FileSystemEvent):
         """
         Handles the event when a new file is created in the watched directory.
         Parameters:
@@ -127,6 +127,9 @@ class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
             
         self.buffer_data.append(data)
         self._notify_observers({self.system_name: data})
+        
+    def on_modified(self, event: FileSystemEvent) -> None:
+        return self.on_created(event)
 
     def update_config(self, config: dict):
         """

--- a/mfi_ddb/data_adapters/mqtt.py
+++ b/mfi_ddb/data_adapters/mqtt.py
@@ -145,6 +145,8 @@ class MqttDataAdapter(BaseDataAdapter, _Mqtt):
     
     RECOMMENDED_TOPIC_FAMILY = "historian"
     
+    SELF_UPDATE = True  # This data adapter will update the data by itself in a separate thread.
+    
     class SCHEMA(BaseDataAdapter.SCHEMA, _SCHEMA.SCHEMA):
         pass        
     

--- a/mfi_ddb/data_adapters/mtconnect.py
+++ b/mfi_ddb/data_adapters/mtconnect.py
@@ -42,7 +42,9 @@ class MTconnectDataAdapter(BaseDataAdapter):
     }
     
     RECOMMENDED_TOPIC_FAMILY = "historian"
-
+    
+    SELF_UPDATE = False
+    
     class SCHEMA(BaseDataAdapter.SCHEMA, _SCHEMA.SCHEMA):
         """
         Schema for the MTConnect data adapter configuration.

--- a/mfi_ddb/data_adapters/ros.py
+++ b/mfi_ddb/data_adapters/ros.py
@@ -51,7 +51,9 @@ class RosDataAdapter(BaseDataAdapter):
         }
     }    
     RECOMMENDED_TOPIC_FAMILY = "historian"
-    
+
+    SELF_UPDATE = True
+
     class SCHEMA(BaseDataAdapter.SCHEMA, _SCHEMA.SCHEMA):
         pass
     

--- a/mfi_ddb/data_adapters/ros_files.py
+++ b/mfi_ddb/data_adapters/ros_files.py
@@ -69,6 +69,8 @@ class RosFilesDataAdapter(BaseDataAdapter):
     }
     RECOMMENDED_TOPIC_FAMILY = "blob"
     
+    SELF_UPDATE = True
+    
     class SCHEMA(BaseDataAdapter.SCHEMA, _SCHEMA.SCHEMA):
         pass
 

--- a/mfi_ddb/streamer/streamer.py
+++ b/mfi_ddb/streamer/streamer.py
@@ -99,8 +99,11 @@ class Streamer(Observer):
         self.__last_poll_update = 0
         
         if stream_on_update:
-            self.__data_adp.add_observer(self)
-    
+            if(self.__data_adp.SELF_UPDATE):
+                self.__data_adp.add_observer(self)
+            else:
+                raise Exception("Data adapter does not support self update notifications.")
+
     def disconnect(self):
         try:
             self.__client.disconnect()


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

Added `SELF_UPDATE` property to all data adapters and LocalFilesDataAdapter tracks modifications

### Details

* **describe existing state (e.g., current console output, results, etc.).**
  * LocalFilesDataAdapter only streams new files when created, and modifications are not streamed.
  * Not all data adapters can be used for the `stream_on_update` flag in the streamer class. For example, MTConnect, by design, is a polling-based protocol, and hence, the data adapter doesn't have any callback upon a change in data.

* **details for the new changes**
  * The application layer on top of the streamer can now select `stream_on_update` flag true or false, based on whether the data adapter class has `SELF_UPDATE==True` 

* **reference relevant README files to understand the new utility**
  * BaseDataAdapter class has the property SELF_UPDATE. Feel free to add suggestions on where we can add documentation for the contribution.

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* Only having `SELF_UPDATE` assumes that all adapters have polling capability by default. It may be possible that adapters for future data sources (or data generators) may not allow for a polling capability.
  * Although a workaround exists in a few existing adapters. For example, LocalFilesDataAdapter and RosDataAdapter primarily use _self_update_ capabliity, and store data in a buffer when `get_data()` method is called. 
* Streamer raises an exception if initialized with initialized with `stream_on_update=True`, and a data adapter with SELF_UPDATE=False. 
* LocalFilesDataAdapter tracks creation and modifications of the file content, but not directory changes or file deletions. Those events are not tracked and streamed.


### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* If we need to track file deletions with LocalFilesDataAdapter, we might require changes in blob data schema to include flags/attributes to stream those file-related metadata events. We can revisit this once retrieval is stable, and we understand how that metadata information can be used. 
