### PR TITLE
🌟 Enhancement: Create CFS connector module and added unique names to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,23 @@ When streaming data to the broker, the following metadata is recorded through th
 | attributes | Key-value pairs that provide additional information about the data being streamed. These are defined in the adapter yaml configuration file. | streamed on the same topic before data using the same topic family encoding |
 | streaming configuration | The configuration of the data stream, which includes broker information, enterprise and site details. | streamed on the `kv` and `blob` at birth and death of data streaming  |
 | adapter configuration | The configuration of the adapter that is streaming the data, which includes all the components and their attributes | streamed on the `kv` and `blob` at birth and death of data streaming |  
+
+## Executable Modules
+
+### [store_cfs.py](mfi_ddb/scripts/store_cfs.py)
+
+```
+usage: store_cfs.py [-h] mqtt_config_path cfs_config_path
+
+Subscribe to a topic and save files based on configuration.
+
+positional arguments:
+  mqtt_config_path  Path to the MQTT configuration file (e.g., mqtt.yaml).
+  cfs_config_path   Path to the CFS configuration file (e.g., cfs.yaml).
+```
+
+```
+# Example usage:
+
+python -m mfi_ddb.scripts.store_cfs path/to/mqtt.yaml path/to/cfs.yaml
+```

--- a/examples/store_files_cfs.py
+++ b/examples/store_files_cfs.py
@@ -1,5 +1,6 @@
 import json
 import os
+import uuid
 
 import yaml
 
@@ -12,6 +13,9 @@ def read_config():
         open(os.path.join(current_dir, f'{name}.yaml'))) for name in ['mqtt', 'cfs'])
 
     return mqtt, cfs
+
+def generate_uid():
+    return str(uuid.uuid4())[-12:]
 
 def callback(config, message):
     data_type, data = BlobTopicFamily.process_message(message)
@@ -35,7 +39,8 @@ def callback(config, message):
         save_dir = config['save_directory']
         os.makedirs(save_dir, exist_ok=True)
         
-        file_name = f"{data['file_name']}"
+        unique_id = generate_uid()
+        file_name = f"{unique_id}.{data['file_type']}"
         file_path = os.path.join(save_dir, file_name)
         with open(file_path, 'wb') as file:
             file.write(data["file"])
@@ -43,7 +48,7 @@ def callback(config, message):
         
         # SAVE METADATA FILE
         data.pop("file")
-        metadata_file_name = f"{data['file_name']}.json"
+        metadata_file_name = f"{unique_id}.json"
         metadata_file_path = os.path.join(save_dir, metadata_file_name)
         with open(metadata_file_path, 'w') as file:
             json.dump(data, file, indent=4)

--- a/mfi_ddb/scripts/store_cfs.py
+++ b/mfi_ddb/scripts/store_cfs.py
@@ -1,0 +1,84 @@
+import json
+import os
+import uuid
+import argparse
+
+import yaml
+
+from mfi_ddb import BlobTopicFamily, Subscriber
+from mfi_ddb.utils.script_utils import get_topic_from_config
+
+def generate_uid():
+    return str(uuid.uuid4())[-12:]
+
+def callback(config, message):
+    data_type, data = BlobTopicFamily.process_message(message)
+    print(f"Received {data_type} message with keys: {data.keys()}")
+
+    if data_type == "attributes":
+        attributes_file_name = f"{data['trial_id']}_{data['timestamp']}.json"
+        attributes_file_path = os.path.join(config['save_directory'], attributes_file_name)
+        with open(attributes_file_path, 'w') as file:
+            json.dump(data['description'], file, indent=4)
+        print(f"Attributes saved at: {attributes_file_path}")
+        print("===========================\n")
+
+    if data_type == "data":
+        # SAVE DATA FILES
+        expected_keys = ["file_name", "file_type", "size", "timestamp", "file"]
+        if not all(key in data for key in expected_keys):
+            print("WARNING: Missing keys in the received message.")
+            return
+        
+        save_dir = config['save_directory']
+        os.makedirs(save_dir, exist_ok=True)
+        
+        unique_id = generate_uid()
+        file_name = f"{unique_id}.{data['file_type']}"
+        file_path = os.path.join(save_dir, file_name)
+        with open(file_path, 'wb') as file:
+            file.write(data["file"])
+        print(f"File saved at: {file_path}")
+        
+        # SAVE METADATA FILE
+        data.pop("file")
+        metadata_file_name = f"{unique_id}.json"
+        metadata_file_path = os.path.join(save_dir, metadata_file_name)
+        with open(metadata_file_path, 'w') as file:
+            json.dump(data, file, indent=4)
+        print(f"Metadata saved at: {metadata_file_path}")
+        print("===========================\n")
+    
+
+def main(mqtt_cfg_file, cfs_cfg_file):
+
+    print(f"Using MQTT config file: {os.path.abspath(mqtt_cfg_file)}\n")
+    print(f"Using CFS config file: {os.path.abspath(cfs_cfg_file)}\n")
+
+    # LOAD CONFIG FILES
+    mqtt_config = yaml.safe_load(open(mqtt_cfg_file))
+    cfs_config = yaml.safe_load(open(cfs_cfg_file))
+
+    breakpoint()
+    # INIT A CONNECTION
+    mqtt_sub = Subscriber(mqtt_config)
+
+    # SUBSCRIBE TO TOPIC AND SET A CALLBACK
+    topic = get_topic_from_config(cfs_config['topic'])
+    mqtt_sub.create_message_callback(
+        topic, lambda message: callback(cfs_config, message))
+
+    mqtt_sub.client.loop_start()
+    
+    while KeyboardInterrupt:
+        pass
+    
+    mqtt_sub.client.loop_stop()
+    mqtt_sub.client.disconnect()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Subscribe to a topic and save files based on configuration.")
+    parser.add_argument("mqtt_config_path", help="Path to the MQTT configuration file (e.g., mqtt.yaml).")
+    parser.add_argument("cfs_config_path", help="Path to the CFS configuration file (e.g., cfs.yaml).")
+    args = parser.parse_args()
+    main(args.mqtt_config_path, args.cfs_config_path)

--- a/mfi_ddb/scripts/store_cfs.py
+++ b/mfi_ddb/scripts/store_cfs.py
@@ -34,7 +34,10 @@ def callback(config, message):
         os.makedirs(save_dir, exist_ok=True)
         
         unique_id = generate_uid()
-        file_name = f"{unique_id}.{data['file_type']}"
+        if data['file_type'][0] == ".":
+            file_name = f"{unique_id}{data['file_type']}"
+        else:
+            file_name = f"{unique_id}.{data['file_type']}" 
         file_path = os.path.join(save_dir, file_name)
         with open(file_path, 'wb') as file:
             file.write(data["file"])
@@ -59,7 +62,6 @@ def main(mqtt_cfg_file, cfs_cfg_file):
     mqtt_config = yaml.safe_load(open(mqtt_cfg_file))
     cfs_config = yaml.safe_load(open(cfs_cfg_file))
 
-    breakpoint()
     # INIT A CONNECTION
     mqtt_sub = Subscriber(mqtt_config)
 


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

Write files for CFS (Cloud File Storage) with a unique name. Also, added store_files_cfs.py to the mfi_ddb Python module.

### Details

* **describe existing state (e.g., current console output, results, etc.).**
  * Files are currently stored on disk, using examples/store_files_cfs.py, with the same name as defined in the payload dictionary key, file_name.
  * The above creates a high chance of collision and overwrite if the file of the same name is streamed at a later time or by some other system.

* **steps to verify the enhancement (how to run the new code and observe the improvement).**
  * The files are now saved on disk with a random name of 12 alpha-numeric digits, trimmed from [uuid4](https://docs.python.org/3/library/uuid.html#uuid.uuid4) as specified in [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122.html).
  * CFS script can now be run using the following terminal command after mfi_ddb installation
```
python -m mfi_ddb.scripts.store_cfs path/to/mqtt.yaml path/to/cfs.yaml
``` 

* **reference relevant README files to understand the new utility**
  * Main README.md has been updated with a [new section](https://github.com/cmu-mfi/mfi_ddb_library/blob/2fe7ead6c2cd32776723dd27cf1aca50c276a87d/README.md?plain=1#L88)

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* As long as we remain under a few million file names ( or 1.62×10^11), chances of conflicting names are rare.
  * projects like git where a few million commits are possible, such an [issue](https://people.kernel.org/kees/colliding-with-the-sha-prefix-of-linuxs-initial-git-commit) might occur
* The connector module has been tested to work with relative file paths (relative to the working directory of the terminal). Tested only on the Linux system (Ubuntu 20.04). Windows might have issues due to a different file path convention.


### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* Currently, it uses a random file name. It might be worth exploring if using a deterministic string generation, like SHA, is a better approach, since that can guarantee no collisions and avoid saving duplicate data.
