### PR TITLE
🐞 Bug Fix: ROS data adapter not working with callbacks

### DIFF
--- a/examples/ros.yaml
+++ b/examples/ros.yaml
@@ -1,5 +1,4 @@
 trial_id: 'untitled'
-set_ros_callback: False
 
 devices:
   yk_architect:

--- a/examples/stream_ros.py
+++ b/examples/stream_ros.py
@@ -1,8 +1,10 @@
 import os
+import signal
+import time
 
 import yaml
 
-from mfi_ddb import Streamer, RosDataAdapter
+from mfi_ddb import RosDataAdapter, Streamer
 
 if __name__ == "__main__":
 
@@ -18,7 +20,32 @@ if __name__ == "__main__":
         mqtt_config = yaml.load(file, Loader=yaml.FullLoader)
 
     ros_adapter = RosDataAdapter(ros_config)
-    streamer = Streamer(mqtt_config, ros_adapter)
+    choice = input("Choose the streaming method:\n1. Polling\n2. Callback\n")
+    while choice not in ["1", "2"]:
+        choice = input("Invalid choice. Choose 1 or 2:\n1. Polling\n2. Callback\n")
 
-    while True:
-        streamer.poll_and_stream_data()
+    is_running = True
+    def signal_handler(sig, frame):
+        global is_running
+        is_running = False
+        print("\nShutting down...")
+        exit(0)
+    
+    signal.signal(signal.SIGINT, signal_handler)
+
+    if choice == "1":
+        print("Polling method selected.")
+
+        streamer = Streamer(mqtt_config, ros_adapter)
+        while is_running:
+            streamer.poll_and_stream_data()
+            
+    elif choice == "2":
+        print("Callback method selected.")
+
+        streamer = Streamer(mqtt_config, ros_adapter, stream_on_update=True)
+        is_running = True
+
+        while is_running:
+            time.sleep(1)
+        

--- a/mfi_ddb/streamer/_mqtt_spb.py
+++ b/mfi_ddb/streamer/_mqtt_spb.py
@@ -138,7 +138,7 @@ class MqttSpb:
     
     def __check_data(self, data: dict):
         for key in data.keys():
-            if type(data[key]) not in [int, float, str, list]:
+            if type(data[key]) not in [int, float, str, list, bool]:
                 return False         
             if type(data[key]) == list:
                 if len(data[key]) > MAX_ARRAY_SIZE:


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

The ROS data adapter was erroring out when using the streaming callback. The root cause was the conflict between the ROS spin thread and the main thread. 

### Details

* The data adapter is unified for both polling and callback, by actively updating data using callback, and Streamer can choose to add an observer or use the `get_data` method.
* The `get_data` method will wait for 0.1s to ensure all topics are updated before returning to Streamer.
* This unification removes the need for the additional parameter, `set_ros_callback`, in the ros.yaml file.
* Changed the `stream_ros.py` example to include both polling and callback options.


* **additional details**
  * Made a minor edit to _mqtt_spb.py to fix bug #37. The solution was in the bug post. So, thanks @ssterenruta.

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* The polling method is not super reliable since its performance depends on the polling rate and the number of topics.
  * `get_data()` method in RosDataAdapter has a fixed 0.1s wait, but if there are many topics, that may not be enough to get the latest data value.
  * RosDataAdapter is not using a buffer, so the data during the wait between polls will be lost.


### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* Current implementation of the ROS subscription is single-threaded. For better performance, we might need to add multi-threaded asynchronous callbacks.
* Fixing bug #37 highlighted that we are not considering [all possible Python datatypes](https://www.w3schools.com/python/python_datatypes.asp). We might need to test and implement error handling against other data types, like complex, tuple, range, etc.
