### PR TITLE
Feature: Metadata store

### DIFF
--- a/metadata-store/README.md
+++ b/metadata-store/README.md
@@ -1,0 +1,95 @@
+# Metadata Store
+## Overview
+The Metadata Store is the central, authoritative database for tracking the complete lifecycle of our experiments (referred to as "trials") and the projects they belong to. Its primary purpose is to provide a durable, queryable, and auditable record of every trial from its creation to its completion.
+
+## Core concepts
+The data model is built around two core entities:
+1. `Project`: Represents a high-level research initiative. Each project has its own set of details and can contain multiple trials.
+2. `Trial`: Represents a single, unique experiment that belongs to a project. A trial's lifecycle is captured through birth and death timestamps, and its status is tracked with a clean_exit flag.
+
+Each project and trial contains a flexible JSON payload, allowing us to record rich, semi-structured data without being constrained by a rigid schema.
+
+## Architecture
+The metadata store is implemented using a hybrid model in PostgreSQL, combining the reliability of a relational database with the flexibility of a document store.
+
+### Technology Stack
+Database: PostgreSQL
+
+Data Type for Metadata: JSONB
+
+### Database Schema
+
+The schema consists of two primary tables, `project_detail` and `trial_detail`, to ensure data integrity for the core entities. Flexibility is provided by JSONB columns in both tables, which store semi-structured metadata for projects and trials. For ER Diagram [click here](https://editor.plantuml.com/uml/lPBVIyCm4CVVyrSSVTgA6ohiPOonJZhyqRLZhGg-bDYS64swabx1CVQ_cxPqu6GeFfY71Ew-b-JplPkLn0rLMh7oNUO5Drn3ILk5TZSo8yOm9qbRACpc3JDA1HAN2dOCx7B1TRk45AuBOtZmrbVNthftEHhrOJ9PtKsdZNGmQ8wSQpnIDV7C82SKAIURJMwMVfnuorNo1BimIY2y3u8p4FZ2AqKGHe-z_hufgmhnbx8MehGrjt4Kpjd-W6cXkVeEsOP_X_YJ9OjE_omDlQOaDTecwE8KGVTbVbhSMgYGvob-oDgBUHG5lXV2hgDVU47ijrTfIsTjumVy_ss0DVjec9mBnve7plbmw3fVMp06Wwf-0MZ3PfYBUbG_0G00)
+
+#### Table `project_detail`
+```
+CREATE TABLE project_detail (
+    project_id       VARCHAR(255) PRIMARY KEY,
+    name      	     VARCHAR(255),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    details	         JSONB
+);
+```
+
+#### Table `trial_detail`
+```
+CREATE TABLE trial_detail (
+    trial_id         VARCHAR(255) PRIMARY KEY,
+    project_id       VARCHAR(255) REFERENCES project_detail(project_id),
+    birth_timestamp  TIMESTAMPTZ  NOT NULL,
+    death_timestamp  TIMESTAMPTZ,
+    clean_exit	     BOOLEAN DEFAULT FALSE,
+    metadata         JSONB,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+#### Function `set_updated_at_timestamp` to be used in triggers for updating the column `updated_at` in different tables
+```
+CREATE OR REPLACE FUNCTION set_updated_at_timestamp()
+ RETURNS TRIGGER AS $$
+ BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+ END;
+$$ LANGUAGE plpgsql;
+```
+
+#### Trigger `project_detail_set_updated_at` to update `updated_at` column in `project_detail` table
+```
+DROP TRIGGER IF EXISTS project_detail_set_updated_at ON project_detail;
+CREATE TRIGGER project_detail_set_updated_at
+BEFORE UPDATE ON project_detail
+FOR EACH ROW
+EXECUTE PROCEDURE set_updated_at_timestamp();
+```
+
+#### Trigger `trial_detail_set_updated_at` to update `updated_at` column in `trial_detail` table
+```
+DROP TRIGGER IF EXISTS trial_detail_set_updated_at ON trial_detail;
+CREATE TRIGGER trial_detail_set_updated_at
+BEFORE UPDATE ON trial_detail
+FOR EACH ROW
+EXECUTE PROCEDURE set_updated_at_timestamp();
+```
+
+## Dynamic Graph Layer
+A key feature of the metadata store is its ability to represent a graph of interconnected data without requiring a separate graph database. This is achieved through a simple tagging syntax and a "Connector" process.
+- **Tagging**: Users can create relationships by embedding tags directly within the metadata or details JSON fields.
+  - **Categorical Tags**: `#project-phoenix`, `#calibration-run`
+  - **Entity Links**: `trial:trial-abc-123` (links to another trial)
+- **Connector**: A background process parses the JSON of new or updated records, identifies these tags, and populates the `graph_edges` table.
+
+This approach transforms implicit references into explicit, queryable relationships, allowing us to perform graph-style queries using standard SQL.
+
+### Table `graph_edges`
+```
+CREATE TABLE graph_edges (
+    edge_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_trial_id    VARCHAR(255) NOT NULL REFERENCES trial_detail(trial_id),
+    target_entity_id   VARCHAR(255) NOT NULL,
+    target_entity_type VARCHAR(50) NOT NULL --  ('trial', 'project', 'tag')
+);
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ watchdog>=4.0.2
 wheel>=0.45.1
 xmltodict>=0.14.2
 pydantic>=2.10.6
+psycopg2-binary>=2.9.11x

--- a/src/mfi_ddb/db_connectors/metadata_store/metadata_utils.py
+++ b/src/mfi_ddb/db_connectors/metadata_store/metadata_utils.py
@@ -1,0 +1,219 @@
+"""
+Reusable utilities for inserting rows into the metadata store tables.
+
+Design considerations:
+- Safe SQL composition (psycopg2.sql) to avoid injection via table/column names
+- Generic `_insert` helper that omits columns when value is None so DB defaults apply
+- Per-table convenience wrappers that map higher-level arguments into columns
+
+Usage example:
+    from mfi_ddb.scripts import metadata_utils as mu
+    row = mu.insert_user_detail('alice', 'example.com', email='a@x.com')
+    print(row)
+
+Requires: psycopg2
+    pip install psycopg2-binary
+"""
+
+from typing import Optional, Tuple, Dict, Any, List
+import os
+import psycopg2
+from psycopg2 import sql
+import psycopg2.extras
+
+_ALLOWED_TABLES = {
+    "user_detail",
+    "project_detail",
+    "trial_detail",
+    "user_project_role_linking",
+    "graph_edges",
+}
+
+
+def get_conn_from_env():
+    params = {
+        "host": os.environ.get("METADASTORE_PGHOST"),
+        "port": int(os.environ.get("METADASTORE_PGPORT")),
+        "user": os.environ.get("METADASTORE_PGUSER"),
+        "password": os.environ.get("METADASTORE_PGPASSWORD"),
+        "dbname": os.environ.get("METADASTORE_PGDATABASE"),
+    }
+    return psycopg2.connect(**params)
+
+
+def _validate_table(table: str):
+    if table not in _ALLOWED_TABLES:
+        raise ValueError(f"Table '{table}' is not allowed. Allowed: {sorted(_ALLOWED_TABLES)}")
+
+
+def _insert(table: str, values: Dict[str, Any]) -> Dict[str, Any]:
+    """Generic insert helper.
+
+    - Omits keys with value is None so DB defaults (e.g., DEFAULT gen_random_uuid()) apply.
+    - Uses psycopg2.sql to safely compose identifiers.
+    - Returns the inserted row as a dict.
+    """
+    _validate_table(table)
+
+    # Filter out None values so DB defaults apply
+    cols = [k for k, v in values.items() if v is not None]
+    vals = [values[k] for k in cols]
+
+    if not cols:
+        raise ValueError("No columns to insert")
+
+    # Convert python dict/list to JSON wrapper for psycopg2
+    processed_vals: List[Any] = []
+    for v in vals:
+        if isinstance(v, (dict, list)):
+            processed_vals.append(psycopg2.extras.Json(v))
+        else:
+            processed_vals.append(v)
+
+    placeholders = [sql.Placeholder() for _ in cols]
+
+    query = sql.SQL("INSERT INTO {table} ({fields}) VALUES ({values}) RETURNING *;").format(
+        table=sql.Identifier(table),
+        fields=sql.SQL(", ").join(map(sql.Identifier, cols)),
+        values=sql.SQL(", ").join(placeholders),
+    )
+
+    conn = get_conn_from_env()
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(query, processed_vals)
+            row = cur.fetchone()
+            conn.commit()
+            return dict(row) if row is not None else {}
+    finally:
+        conn.close()
+
+
+def _update_trial_end(trial_name: str,
+                      death_timestamp: int,
+                      clean_exit: bool = True) -> Dict[str, Any]:
+    """Update an existing trial_detail row with end-of-life fields.
+
+    Returns the updated row as a dict. No-op (empty dict) if no row matched.
+    """
+    _validate_table("trial_detail")
+    query = sql.SQL(
+        """
+        UPDATE {table}
+        SET death_timestamp = %s,
+            clean_exit = %s
+        WHERE trial_name = %s
+        RETURNING *;
+        """
+    ).format(table=sql.Identifier("trial_detail"))
+
+    conn = get_conn_from_env()
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(query, [death_timestamp, clean_exit, trial_name])
+            row = cur.fetchone()
+            conn.commit()
+            return dict(row) if row is not None else {}
+    finally:
+        conn.close()
+
+
+def insert_user_detail(user_id: str,
+                       domain: str,
+                       email: Optional[str] = None,
+                       name: Optional[str] = None,
+                       created_by: Optional[Tuple[str, str]] = None) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        "user_id": user_id,
+        "domain": domain,
+        "email": email,
+        "name": name,
+    }
+    if created_by:
+        data["created_by_user_id"] = created_by[0]
+        data["created_by_domain"] = created_by[1]
+    else:
+        data["created_by_user_id"] = "superadmin"
+        data["created_by_domain"] = "superadmin"
+
+    return _insert("user_detail", data)
+
+
+def insert_project_detail(project_id: Optional[str] = None,
+                          name: Optional[str] = None,
+                          details: Optional[Dict[str, Any]] = None,
+                          created_by: Optional[Tuple[str, str]] = None) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        "project_id": project_id,
+        "name": name,
+        "details": details,
+    }
+    if created_by:
+        data["created_by_user_id"] = created_by[0]
+        data["created_by_domain"] = created_by[1]
+    else:
+        data["created_by_user_id"] = "superadmin"
+        data["created_by_domain"] = "superadmin"
+
+    return _insert("project_detail", data)
+
+
+def insert_trial_detail(trial_name: str,
+                        user_id: str,
+                        user_domain: str,
+                        project_id: Optional[str],
+                        birth_timestamp,
+                        death_timestamp=None,
+                        clean_exit: Optional[bool] = None,
+                        metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        "trial_name": trial_name,
+        "user_id": user_id,
+        "user_domain": user_domain,
+        "project_id": project_id,
+        "birth_timestamp": birth_timestamp,
+        "death_timestamp": death_timestamp,
+        "clean_exit": clean_exit,
+        "metadata": metadata,
+    }
+    return _insert("trial_detail", data)
+
+
+def update_trial_detail_end(trial_name: str,
+                            death_timestamp: int,
+                            clean_exit: bool = True) -> Dict[str, Any]:
+    """Public wrapper to update trial end fields.
+
+    Example:
+        update_trial_detail_end("AIDF_FINAL_DEMO", 1700000000, True)
+    """
+    return _update_trial_end(trial_name, death_timestamp, clean_exit)
+
+
+def insert_user_project_role_linking(user_id: str,
+                                    domain: str,
+                                    project_id: str,
+                                    role: str,
+                                    id: Optional[str] = None) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        # if `id` is None we omit it so DB default gen_random_uuid() applies
+        "id": id,
+        "user_id": user_id,
+        "domain": domain,
+        "project_id": project_id,
+        "role": role,
+    }
+    return _insert("user_project_role_linking", data)
+
+
+def insert_graph_edge(source_trial_id: str,
+                      target_entity_id: str,
+                      target_entity_type: str,
+                      edge_id: Optional[str] = None) -> Dict[str, Any]:
+    data = {
+        "edge_id": edge_id,
+        "source_trial_id": source_trial_id,
+        "target_entity_id": target_entity_id,
+        "target_entity_type": target_entity_type,
+    }
+    return _insert("graph_edges", data)

--- a/src/mfi_ddb/db_connectors/metadata_store/store_metadata.py
+++ b/src/mfi_ddb/db_connectors/metadata_store/store_metadata.py
@@ -1,0 +1,184 @@
+"""MQTT -> metadata store bridge.
+
+This script demonstrates subscribing to a blob topic, extracting an "attributes"
+payload and inserting a trial row into PostgreSQL using the helper functions in
+`metadata_utils.py`.
+
+Usage:
+    python store_metadata.py <mqtt_cfg.yaml> <metadata_cfg.yaml>
+
+The metadata config is expected to contain a `topic` field like other store_* scripts.
+This is a small example — adapt field mapping to your real message schema.
+"""
+from typing import Any, Dict
+import os
+import argparse
+import yaml
+import time
+from datetime import datetime, timezone
+import json
+import re
+import zipfile
+
+from mfi_ddb import BlobTopicFamily, Subscriber
+from mfi_ddb.utils.script_utils import get_topic_from_config
+
+import metadata_utils as mu
+
+
+def _handle_attributes_message(data: Dict[str, Any]):
+    """Map the blob attributes message into a trial insert and call metadata_utils.
+    """
+    # Helper to parse ISO timestamps safely
+    def _to_epoch_seconds(iso_ts: Any) -> int:
+        if isinstance(iso_ts, (int, float)):
+            return int(iso_ts)
+        if isinstance(iso_ts, str):
+            try:
+                dt = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return int(dt.timestamp())
+            except Exception:
+                pass
+        return int(time.time())
+
+    adapter = data.get("adapter", {}) or {}
+    broker = data.get("broker", {}) or {}
+    broker_mqtt = broker.get("mqtt", {}) or {}
+    time_block = data.get("time", {}) or {}
+
+    # trial_name priority: adapter.config.trial_id -> adapter.attributes.trial_id -> top-level trial_id
+    trial_id = (adapter.get("config", {}) or {}).get("trial_id")
+
+    # birth timestamp from ISO string, fallback to now
+    timestamp = _to_epoch_seconds(time_block.get("birth"))
+
+    # user/project mapping based on available fields
+    user_id = broker_mqtt.get("username") or "unknown_user"
+    user_domain = broker_mqtt.get("user_domain") or "unknown_domain"
+
+    # Store entire incoming payload as metadata for traceability
+    metadata = data
+
+    if not trial_id:
+        print("No trial_id found in message; skipping insert/update")
+        return
+
+    # If death timestamp is present, update the trial end; else treat as birth insert
+    death_iso = (data.get("time", {}) or {}).get("death")
+    if death_iso:
+        death_ts = _to_epoch_seconds(death_iso)
+        try:
+            row = mu.update_trial_detail_end(
+                trial_name=trial_id,
+                death_timestamp=death_ts,
+                clean_exit=True,
+            )
+            if row:
+                print("Updated trial (death):", row)
+            else:
+                print("No trial row found to update for trial_id:", trial_id)
+        except Exception as exc:
+            print("Error updating trial end detail:", exc)
+        return
+
+    try:
+        row = mu.insert_trial_detail(
+            trial_name=trial_id,
+            user_id=user_id,
+            user_domain=user_domain,
+            birth_timestamp=timestamp,
+            metadata=metadata,
+        )
+        print("Inserted trial row:", row)
+    except Exception as exc:
+        print("Error inserting trial detail:", exc)
+
+
+def callback(config, message):
+    """Parse incoming blob payloads and act on 'attributes' messages."""
+    payload_type, data = BlobTopicFamily.process_message(message)
+    print(f"Received {payload_type} message with keys: {list(data.keys())}")
+
+    if payload_type == "attributes":
+        _handle_attributes_message(data)
+    else:
+        print("Received non-attributes blob message; ignoring for metadata insert.")
+
+
+def _strip_jsonc_comments(text: str) -> str:
+    """Remove // and /* */ comments from JSONC-like text for safe json.loads."""
+    # Remove // comments
+    text = re.sub(r"//.*", "", text)
+    # Remove /* ... */ comments (including multiline)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return text
+
+
+def _process_zip(zip_path: str):
+    print(f"Processing zip file: {os.path.abspath(zip_path)}")
+    if not os.path.isfile(zip_path):
+        print("Zip path does not exist or is not a file:", zip_path)
+        return
+
+    with zipfile.ZipFile(zip_path, 'r') as zf:
+        names = [n for n in zf.namelist() if not n.endswith('/')]
+        if not names:
+            print("Zip archive is empty")
+            return
+        for name in names:
+            if not (name.lower().endswith('.json') or name.lower().endswith('.jsonc')):
+                continue
+            try:
+                with zf.open(name, 'r') as fh:
+                    raw = fh.read().decode('utf-8')
+                if name.lower().endswith('.jsonc'):
+                    raw = _strip_jsonc_comments(raw)
+                payload = json.loads(raw)
+            except Exception as exc:
+                print(f"Failed to parse {name}: {exc}")
+                continue
+
+            print(f"Ingesting {name}")
+            _handle_attributes_message(payload)
+
+
+def main(mqtt_cfg_file: str, metadata_cfg_file: str):
+    print(f"Using MQTT config file: {os.path.abspath(mqtt_cfg_file)}")
+    print(f"Using metadata config file: {os.path.abspath(metadata_cfg_file)}")
+
+    mqtt_config = yaml.safe_load(open(mqtt_cfg_file))
+    metadata_config = yaml.safe_load(open(metadata_cfg_file))
+
+    # Initialize subscriber and subscribe to configured topic
+    mqtt_sub = Subscriber(mqtt_config)
+    topic = get_topic_from_config(metadata_config["topic"])
+    mqtt_sub.create_message_callback(topic, lambda message: callback(metadata_config, message))
+
+    # Run the mqtt loop in background and wait until interrupted
+    try:
+        mqtt_sub.client.loop_start()
+        print("Listening for metadata messages (press Ctrl+C to stop)")
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("Interrupted; shutting down")
+    finally:
+        mqtt_sub.client.loop_stop()
+        mqtt_sub.client.disconnect()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Ingest metadata either from MQTT or a zip of JSON payloads.")
+    parser.add_argument("mqtt_config_path", nargs='?', help="Path to MQTT configuration YAML (e.g., mqtt.yaml)")
+    parser.add_argument("metadata_config_path", nargs='?', help="Path to metadata configuration YAML (e.g., mtconnect.yaml)")
+    parser.add_argument("--zip", dest="zip_path", help="Path to a zip containing birth/death JSON/JSONC payloads for bulk upload")
+    args = parser.parse_args()
+
+    if args.zip_path:
+        _process_zip(args.zip_path)
+    else:
+        if not args.mqtt_config_path or not args.metadata_config_path:
+            parser.error("When --zip is not provided, mqtt_config_path and metadata_config_path are required.")
+        main(args.mqtt_config_path, args.metadata_config_path)


### PR DESCRIPTION
## 🚀 Feature

### Brief Description
* Added metadata-store utilities (metadata_utils.py) aligned with the documented Postgres schema, plus supporting connector code.
* Enables inserting users, projects, trials, roles, and graph edges, plus updating trial end-state, so ingestion scripts can write consistently to the DB.

### Details
* **Test / example:** run python src/mfi_ddb/db_connectors/metadata_store/store_metadata.py <mqtt yaml> <metadata yaml> to exercise trial inserts via live MQTT data.
* Example payloads for manual testing live under src/mfi_ddb/db_connectors/metadata_store/ (birth.json, death.jsonc, test.zip).

### Potential failure points
* Environment variables (METADASTORE_PGHOST, METADASTORE_PGUSER, etc.) missing or misconfigured, causing connection failures or writing to the wrong DB.
* Trial inserts with project_id/user_id referencing non-existent rows will hit foreign-key constraints and throw errors; ingestion must ensure prerequisite rows exist.
_update_trial_end relies on trial_name uniqueness; if duplicate names exist, the wrong row could be updated or no row found.

### Potential improvement
* Add higher-level “upsert” helpers that create projects/users on demand (with caching) and wrap operations in transactions, reducing the orchestration burden on ingestion scripts and preventing partial writes.


