### PR TITLE
🌟 Enhancement: Use dev branch to stage releases to main

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,7 +1,28 @@
 # CI Workflows
 
-| Stage | Job ID             | Job name           | Workflow name         | Workflow file      | Events                       | Description                  |
-|-------|--------------------|--------------------|-----------------------|--------------------|------------------------------|------------------------------|
-| 0     | installation-check | installation-check | CI Checks             | checks.yml         | push,pull_request            | Verifies installation setup  |
-| 0     | check-lockfile     | check-lockfile     | Check and update uv.lock | update-uv-lock.yml | pull_request,workflow_dispatch | Manages uv.lock dependencies |
-| 1     | streaming-check    | streaming-check    | CI Checks             | checks.yml         | push,pull_request            | Tests data adapters |
+This repository uses GitHub Actions for continuous integration and automation. Below are the available workflows organized by priority/stage.
+
+## workflows
+
+
+| Stage | Job ID             | Job name           | Workflow name                  | Workflow file                 | Events                                                                                               | Description                                                      |
+|-------|--------------------|--------------------|--------------------------------|-------------------------------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| 0     | installation-check | installation-check | MFI-DDB Package CI Checks      | ci-checks.yml                 | push to main, pull_request (mfi_ddb_package/src/\*\*)                                                | Verifies installation setup across Ubuntu and Windows            |
+| 0     | streaming-check    | streaming-check    | MFI-DDB Package CI Checks      | ci-checks.yml                 | push to main, pull_request (mfi_ddb_package/src/\*\*)                                                | Tests data adapters (LocalFiles, MQTT, Kv) with EMQX broker     |
+| 0     | ros2-check         | ros2-check         | MFI-DDB Package CI Checks      | ci-checks.yml                 | push to main, pull_request (mfi_ddb_package/src/\*\*)                                                | Runs ROS2 tests                                                  |
+| 1     | check-lockfile     | check-lockfile     | Update uv.lock                 | update-uv-lock.yml            | pull_request (pyproject.toml), workflow_dispatch                                                    | Checks and updates uv.lock for dependency management             |
+| 1     | check-lockfile-admin | check-lockfile   | Update uv.lock (main branch)   | update-uv-lock-admin.yml      | workflow_dispatch                                                                                    | Admin: Updates uv.lock on main branch with PAT authentication  |
+| 2     | generate-configs   | generate-configs   | Generate Config Examples       | generate_config_examples.yaml | pull_request (data_adapters/\*\*, streamer.py), workflow_dispatch                                   | Auto-generates configuration examples from source code           |
+| 3     | sync-dev-to-main   | sync-dev-to-main   | Sync Dev to Main               | sync-dev-to-main.yml          | workflow_dispatch                                                                                    | Merges dev branch into main branch                                |
+
+
+## Stage Priority
+
+- **Stage 0**: Core CI checks (installation, streaming, ROS2 tests) - runs on every push/pull_request to main
+- **Stage 1**: Dependency management (uv.lock updates) - triggers on pyproject.toml changes or manual dispatch
+- **Stage 2**: Configuration examples generation - triggers when data adapter files change
+
+## Notes
+
+- The `ros2-check` job uses a reusable workflow reference (`/mfi_ddb_package/tests/workflows/data_adapters/ros2.yaml`)
+- Admin workflows use personal access tokens (PAT) for elevated permissions on protected branches

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -2,9 +2,9 @@ name: MFI-DDB Package CI Checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
     paths:
       - 'mfi_ddb_package/src/**'
   workflow_dispatch:

--- a/.github/workflows/sync-dev-to-main.yml
+++ b/.github/workflows/sync-dev-to-main.yml
@@ -1,0 +1,36 @@
+name: Sync Dev to Main
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-dev-to-main:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.SHOBHITAGG_PAT }}
+          ref: main
+          fetch-depth: 0
+
+      - name: Configure Git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch all branches and tags
+        run: |
+          git fetch --all
+
+      - name: Sync dev to main
+        run: |
+          # Update main with dev branch changes
+          git merge origin/dev --no-edit
+          
+          # Push the updated main branch
+          git push origin main


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

Introducing `dev` branch where we merge all the PRs, and merge the updates to main when ready for release.

### Details

* **describe existing state (e.g., current console output, results, etc.).**
  * Currently, all PRs merge directly to main. This prevents us from using the main branch as a release branch, since some features might be incomplete without other features/enhancements.

* **steps to verify the enhancement (how to run the new code and observe the improvement).**
  * The workflow in this PR, `sync-dev-to-main.yml`, allows the admin to manually trigger merging the updates from `dev` without deleting the `dev` branch.

* **reference relevant README files to understand the new utility**
  * Updated `.github/workflows/README`

* **additional changes**
  * Existing workflows that triggers automatically on a PR merge to `main` have been edited to include `dev`

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* Offline testing is not applicable. So, the merge might have unforeseen errors when triggered. 
* It uses @shobhitagg's PAT, which has limited time validity. It needs to be regenerated if expired. The .yml file will need to be edited if using any other maintainer's PAT.
* If, for some reason, `main` is ahead of `dev`, it might create merge issues. Admins and maintainers have to make sure that `main` is never ahead of `dev`.


### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* Add parallel workflows, that does the actual releases of publishing the dockers to docker-hub, py-package to pypi hub, and track versions in the root README.
