### PR TITLE
🌟 Enhancement: BaseDataAdapter pydantic SCHEMA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/data_adapters.md
+++ b/.github/PULL_REQUEST_TEMPLATE/data_adapters.md
@@ -42,6 +42,8 @@
 
 - [ ] Update `NAME`, `CONFIG_HELP`, `CONFIG_EXAMPLE`, `RECOMMENDED_TOPIC_FAMILY`, `SELF_UPDATE` class variables.
 
+- [ ] Include `adapter_name` and `trial_id` keys in the config.
+
 - [ ] Constructor checklist:
     - [ ] Use only one dict parameter `config` to initialize the data adapter.
     - [ ] Call `super().__init__(config)` to initialize the base class.

--- a/mfi_ddb_package/examples/configs/data_adapters/grpc.yaml
+++ b/mfi_ddb_package/examples/configs/data_adapters/grpc.yaml
@@ -1,3 +1,4 @@
+adapter_name: my_grpc_adapter
 server_address: localhost
 server_port: 50051
 certificate_path: /full/path/to/cert.pem

--- a/mfi_ddb_package/examples/configs/data_adapters/keyvalue.yaml
+++ b/mfi_ddb_package/examples/configs/data_adapters/keyvalue.yaml
@@ -1,3 +1,4 @@
+adapter_name: my_kv_adapter
 trial_id: booster-a1
 payloads:
 - schema_version: mfi-v1.0

--- a/mfi_ddb_package/examples/configs/data_adapters/local_files.yaml
+++ b/mfi_ddb_package/examples/configs/data_adapters/local_files.yaml
@@ -1,3 +1,4 @@
+adapter_name: my_local_files_adapter
 watch_dir:
 - /path/to/watch/dir
 buffer_size: 10

--- a/mfi_ddb_package/examples/configs/data_adapters/mqtt.yaml
+++ b/mfi_ddb_package/examples/configs/data_adapters/mqtt.yaml
@@ -1,3 +1,4 @@
+adapter_name: my_mqtt_adapter
 mqtt:
   broker_address: mqtt.example.com
   broker_port: 1883

--- a/mfi_ddb_package/examples/configs/data_adapters/mtconnect.yaml
+++ b/mfi_ddb_package/examples/configs/data_adapters/mtconnect.yaml
@@ -1,3 +1,4 @@
+adapter_name: my_mtconnect_adapter
 mtconnect:
   agent_ip: 192.168.1.1
   agent_url: http://192.168.1.1:5000

--- a/mfi_ddb_package/examples/configs/data_adapters/ros.yaml
+++ b/mfi_ddb_package/examples/configs/data_adapters/ros.yaml
@@ -1,3 +1,4 @@
+adapter_name: my_ros_adapter
 trial_id: trial_001
 devices:
   device1:

--- a/mfi_ddb_package/examples/configs/data_adapters/ros2.yaml
+++ b/mfi_ddb_package/examples/configs/data_adapters/ros2.yaml
@@ -1,3 +1,4 @@
+adapter_name: my_ros2_adapter
 trial_id: trial_001
 devices:
   device1:

--- a/mfi_ddb_package/examples/configs/data_adapters/ros_files.yaml
+++ b/mfi_ddb_package/examples/configs/data_adapters/ros_files.yaml
@@ -1,3 +1,4 @@
+adapter_name: my_ros_files_adapter
 trial_id: trial_001
 set_ros_callback: true
 devices:

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/README.md
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/README.md
@@ -39,6 +39,8 @@ When writing a new data adapter, please make sure to follow the checklist below:
 
 - [ ] Update `NAME`, `CONFIG_HELP`, `CONFIG_EXAMPLE`, `RECOMMENDED_TOPIC_FAMILY`, `SELF_UPDATE` class variables.
 
+- [ ] Include `adapter_name` and `trial_id` keys in the config.
+
 - [ ] Constructor checklist:
     - [ ] Use only one dict parameter `config` to initialize the data adapter.
     - [ ] Call `super().__init__(config)` to initialize the base class.
@@ -47,4 +49,3 @@ When writing a new data adapter, please make sure to follow the checklist below:
     - [ ] Initialize `self._data` with component ids as keys.
 
 - [ ] Write unit tests for the new data adapter and add them to [`tests/data_adapters`](../tests/data_adapters)
-

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/base.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/base.py
@@ -17,10 +17,11 @@ class BaseDataAdapter:
 
     class SCHEMA(BaseModel):
         """
-        Schema for the data adapter configuration. 
+        Schema for the data adapter configuration.
         Override this class in the child class to define the schema for the data adapter configuration.
         """
-        pass
+        trial_id: str = Field(..., description="Trial ID for the system. No spaces or special characters allowed.")
+        adapter_name: str = Field("my_adapter", description="(optional) Name of the adapter instance.")
 
     def __init__(self, config: dict = {}) -> None:
         self.component_ids = []
@@ -31,35 +32,40 @@ class BaseDataAdapter:
         # data is a dictionary that contains the data of the components.
         # e.g.: self.data = {"robot-arm-1": {"estop": 0, "joint-1": 0.52},
         #                    "machine-a": {"temperature": 30, "pressure": 100}}
-        # It keeps last updated data that has not been streamed yet for each component_id. 
+        # It keeps last updated data that has not been streamed yet for each component_id.
         # If all up-to-date data has been streamed, it will look like this:
-        # e.g.: self.data = {"robot-arm-1": {}, 
+        # e.g.: self.data = {"robot-arm-1": {},
         #                    "machine-a": {}}
 
         self._cb_data = {}
         # cb_data is a dictionary that contains the data of the components for the callback.
         # Any change in value of cb_data will notify all observers (if any)
         # Valid update: self.cb_data = {"robot-arm-1": {"estop": 1, "joint-1": 0.52}}
-        # Invalid update: self.cb_data["robot-arm-1"] = {"estop": 1, "joint-1": 0.52}        
+        # Invalid update: self.cb_data["robot-arm-1"] = {"estop": 1, "joint-1": 0.52}
 
         self.last_updated = {}
         # last_updated is a dictionary that contains the Unix timestamp in seconds of the last update of the components.
         # e.g.: self.last_updated = {"robot-arm-1": 1632900000.0, "machine-a": 1632900000.0}
-        
+
         self.attributes = {}
         # attributes is a dictionary that contains the attributes of the components.
         # e.g.: self.attributes = {"robot-arm-1": {"manufacturer": "ABB", "model": "IRB 120", "experiment_class": "orange-test-1"},
         #                          "machine-a": {"manufacturer": "Siemens", "model": "S7-1500", "experiment_class": "orange-test-1"}},
-        
+
         self.cfg = config
         # cfg is a dictionary that contains the configuration of the data object.
         # Note on trial_id:
         #   * cfg needs to have a key `trial_id` that will be the default trial_id for the data object.
         #   * if the config file doesn't have a key `trial_id`, use the data adapter class constructor to set it.
         #   * default trial_id will be None if not set.
+        # Note on adapter_name:
+        #   * cfg needs to have a key `adapter_name` that will be the name of the adapter instance
+        #   * if the key doesn't exist, name will be blank.
+        self._trial_id = self.cfg['trial_id']
+        self._adapter_name = self.cfg.get('adapter_name','my_adapter')
 
         self._observers = []  # List of observers (listeners)
-        
+
         self.logger = logging.getLogger(self.__class__.__name__)
 
     def disconnect(self):
@@ -94,7 +100,7 @@ class BaseDataAdapter:
         Setter for data, notify all observers of the update.
         """
         self._cb_data = new_data
-        
+
         # Notify all observers
         self._notify_observers(new_data)
 
@@ -109,11 +115,11 @@ class BaseDataAdapter:
         Update data from the data source. If not defined in the child class, it will call the get_data() method.
         """
         self.get_data()
-            
+
     def update_config(self, config: dict):
         """
         Update the configuration of the data object with the new configuration.
-        
+
         Args:
             config (dict): The new configuration of the data object.
         """
@@ -121,7 +127,7 @@ class BaseDataAdapter:
             self.cfg = config
         else:
             raise ValueError("The configuration is empty!")
-        
+
     def add_observer(self, observer):
         """
         Add an observer (listener) to the list.
@@ -136,12 +142,12 @@ class BaseDataAdapter:
         for observer in self._observers:
             # Run observer callback in a separate thread
             threading.Thread(target=observer.on_data_update, args=(new_value,), daemon=True).start()
-            
+
     def clear_data_buffer(self, component_ids:list=[]):
         """
         Clear the data buffer of each component_id. Used by streamers to clear already streamed data
         """
         component_ids = component_ids if component_ids else self.component_ids
-        
+
         for component_id in component_ids:
-            self.data[component_id] = {}            
+            self.data[component_id] = {}

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/base.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/base.py
@@ -1,7 +1,7 @@
-import threading
 import logging
+import threading
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class BaseDataAdapter:

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/grpc.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/grpc.py
@@ -23,7 +23,7 @@ class _SCHEMA(BaseModel):
         stub_class: str = Field(..., description="Name of the gRPC stub class to use for communication")
         request_class: str = Field(..., description="Name of the request class to use for the gRPC service call.")
         request: dict = Field(..., description="Request parameters for the gRPC service call")
-        
+
     class SCHEMA(BaseModel):
         server_address: str = Field(..., description="Network Address of the gRPC server")
         server_port: int = Field(..., description="Port of the gRPC server")
@@ -32,11 +32,11 @@ class _SCHEMA(BaseModel):
         compiled_protos_dir: str = Field("./compiled_protos", description="Full path to the compiled protobuf stubs (optional)")
         trial_id: str = Field(..., description="Trial ID for the gRPC device. No spaces or special characters allowed.")
         components: List['_GRPCComponent'] = Field(..., description="List of gRPC components to monitor")
-        
+
 class GrpcDataAdapter(BaseDataAdapter):
-    
+
     NAME = "gRPC"
-    
+
     CONFIG_HELP = {
         "server_address": "Network Address of the gRPC server (string)",
         "server_port": "Port of the gRPC server (int)",
@@ -46,8 +46,9 @@ class GrpcDataAdapter(BaseDataAdapter):
         "trial_id": "Trial ID for the gRPC device. No spaces or special characters allowed. (string)",
         "components": "List of gRPC components to monitor (list of dicts with keys: component_id, attributes (optional), proto_path, stub_class, request_class, request)"
     }
-    
+
     CONFIG_EXAMPLE = {
+        "adapter_name": "my_grpc_adapter",
         "server_address": "localhost",
         "server_port": 50051,
         "certificate_path": "/full/path/to/cert.pem",
@@ -85,11 +86,11 @@ class GrpcDataAdapter(BaseDataAdapter):
             }
         ]
     }
-    
+
     RECOMMENDED_TOPIC_FAMILY = "historian"
-    
+
     SELF_UPDATE = False
-    
+
     class SCHEMA(BaseDataAdapter.SCHEMA, _SCHEMA.SCHEMA):
         """
         Schema for the MTConnect data adapter configuration.
@@ -97,10 +98,8 @@ class GrpcDataAdapter(BaseDataAdapter):
         pass
 
     def __init__(self, config: dict):
-        super().__init__()
-        
-        self.cfg = config
-        
+        super().__init__(config)
+
         # 1. OPEN GRPC CHANNEL
         addr = f"{self.cfg['server_address']}:{self.cfg['server_port']}"
         if 'certificate_path' in self.cfg:
@@ -115,7 +114,7 @@ class GrpcDataAdapter(BaseDataAdapter):
         except grpc.FutureTimeoutError:
             raise ConnectionError('Error connecting to gRPC server')
         print(f"Connected to gRPC server at {addr}")
-        
+
         # 2. PREPARE COMPILED PROTOBUFS
         if not os.path.exists(self.cfg['compiled_protos_dir']):
             os.makedirs(self.cfg['compiled_protos_dir'])
@@ -135,7 +134,7 @@ class GrpcDataAdapter(BaseDataAdapter):
             sys.path.append(str(proto_full_path.parent.resolve()))
             # Import compiled protobuf stubs dynamically
             # ``````````````````````````````````````````
-            
+
             stub_module = importlib.import_module(f"{proto_name}_pb2_grpc")
             if not stub_module:
                 if not self.did_i_compile_once:
@@ -145,10 +144,10 @@ class GrpcDataAdapter(BaseDataAdapter):
                 raise ImportError(f"Could not import compiled protobuf module for {proto_name}")
 
             stub_class = getattr(stub_module, component['stub_class'])
-            
+
             # Import compiled protobuf request dynamically
-            # ``````````````````````````````````````````            
-            
+            # ``````````````````````````````````````````
+
             request_module = importlib.import_module(f"{proto_name}_pb2")
             if not request_module:
                 if not self.did_i_compile_once:
@@ -159,9 +158,9 @@ class GrpcDataAdapter(BaseDataAdapter):
 
             request_class = getattr(request_module, component['request_class'])
             request_dict = component['request']
-            
+
             # Instantiate stub and request
-            # ````````````````````````````            
+            # ````````````````````````````
             stub = stub_class(self.channel)
             request_instance = request_class(**request_dict)
 
@@ -173,7 +172,7 @@ class GrpcDataAdapter(BaseDataAdapter):
             self.component_ids.append(component['component_id'])
             self.attributes[component['component_id']] = component
             self._data[component['component_id']] = {}
-            
+
 
             self.components.append({
                 'component_id': component['component_id'],
@@ -189,7 +188,7 @@ class GrpcDataAdapter(BaseDataAdapter):
             # Assuming response has a 'data' attribute; adjust as needed
             self._data[comp['component_id']] = self.__process_data(raw_response)
             self.last_updated[comp['component_id']] = time.time()
-        
+
     def __generate_compiled_protos(self):
         '''
         #!/bin/bash
@@ -233,7 +232,7 @@ class GrpcDataAdapter(BaseDataAdapter):
             subprocess.run(cmd, check=True)
 
         print("Compiled protobufs successfully.")
-            
+
     def __process_data(self, raw_response):
         '''
         Convert to strict keyed dict
@@ -244,7 +243,7 @@ class GrpcDataAdapter(BaseDataAdapter):
              processed_data.update(self.__extract_key_value(raw_data[key], key))
 
         return processed_data
-    
+
     def __extract_key_value(self, data_item, data_item_key):
         if len(data_item_key) > 0 and data_item_key[0] == '/':
             data_item_key = data_item_key[1:]
@@ -261,7 +260,7 @@ class GrpcDataAdapter(BaseDataAdapter):
             return extracted_data
         else:
             return {data_item_key: self.__autotype(data_item)}
-    
+
     def __autotype(self, value):
         for cast in (int, float, eval):
             try:
@@ -274,4 +273,4 @@ class GrpcDataAdapter(BaseDataAdapter):
             except:
                 continue
 
-        return value        
+        return value

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/key_value.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/key_value.py
@@ -11,21 +11,22 @@ class _SCHEMA(BaseModel):
         model_config = ConfigDict(extra='allow')
         schema_version: str = Field("mfi-v1.0", description="Version of kv schema to validate the payload.")
         msg_type: Literal['data', 'project', 'tp-tag', 'user'] = Field("data", description="OneOf('data', 'project', 'tp-tag', 'user')")
-        
+
     class SCHEMA(BaseModel):
         trial_id: str = Field("mfi-ddb-metadata", description="(optional) It is required if one of the payload is of type 'data'")
         payloads: List['_Payload'] = Field(..., description="List of payload messages. Payloads of type 'data', 'project', 'tp-tag', and 'user' allowed. Each will be verified against the kv.json schema.")
-                
+
 class KvDataAdapter(BaseDataAdapter):
-    
+
     NAME = "KeyValue"
-    
+
     CONFIG_HELP = {
         'trial_id': "(optional) It is required if one of the payload is of type 'data'",
         "payloads": "List of payload messages. Payloads of type 'data', 'project', 'tp-tag', and 'user' allowed. Each will be verified against the kv.json schema."
     }
-    
+
     CONFIG_EXAMPLE = {
+        'adapter_name': 'my_kv_adapter',
         'trial_id': 'booster-a1',
         'payloads':[
             {
@@ -67,32 +68,32 @@ class KvDataAdapter(BaseDataAdapter):
             "created_by_user_id": "researcher_01",
             "created_by_domain": "university_net",
             "timestamp": "2026-03-31T23:34:00Z"
-            },                        
+            },
             {
             "schema_version": "mfi-v1.0",
             "msg_type": "data",
             "payload": "Custom data here",
             "value": 42
-            }                       
+            }
         ]
     }
-    
+
     RECOMMENDED_TOPIC_FAMILY = "kv"
-    
+
     SELF_UPDATE = False
-    
+
     class SCHEMA(BaseDataAdapter.SCHEMA, _SCHEMA.SCHEMA):
         pass
 
     def __init__(self, config: dict):
-        super().__init__()
-        
-        self.cfg = config
+
         try:
-            self.cfg = KvDataAdapter.SCHEMA(**config).model_dump()
+            config = KvDataAdapter.SCHEMA(**config).model_dump()
         except Exception as e:
-            raise ConfigError(f"Invalid configuration: {e}")   
-        
+            raise ConfigError(f"Invalid configuration: {e}")
+
+        super().__init__(config)
+
         self.pending_payloads = {}
         schema_validator = KeyValueTopicFamily.get_schema_validator()
         for payload in self.cfg['payloads']:
@@ -101,19 +102,19 @@ class KvDataAdapter(BaseDataAdapter):
                 self.logger.warning(f"Payload does not match schema: {schema_validator.iter_errors(payload)}")
                 self.logger.warning("Skippidng the payload...")
                 continue
-            
+
             if payload['msg_type']=='data' and self.cfg['trial_id']=="mfi-ddb-metadata":
                 self.logger.warning("WARNING: No trial_id provided. Payload of type 'data' is ignored.")
                 continue
-            
+
             if payload['msg_type'] in self.component_ids:
                 self.pending_payloads[payload['msg_type']].append(payload)
             else:
                 self.component_ids.append(payload['msg_type'])
                 self.pending_payloads[payload['msg_type']] = [payload]
                 self.attributes[payload['msg_type']] = {'type': payload['msg_type']}
-                self._data[payload['msg_type']] = {}                               
-        
+                self._data[payload['msg_type']] = {}
+
     def get_data(self):
         for key in self._data.keys():
             self.logger.info(f"sending {key} payload")

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/local_files.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/local_files.py
@@ -15,9 +15,9 @@ from mfi_ddb.data_adapters.base import BaseDataAdapter
 
 
 class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
-    
+
     NAME = "Local Files"
-    
+
     CONFIG_HELP = {
         "watch_dir": "List of directories to watch for new files. The first directory will be used to create a starter file.",
         "buffer_size": "Maximum number of files to buffer before streaming. If the buffer is full, the oldest file will be removed.",
@@ -29,8 +29,9 @@ class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
             "other_attributes": "Other attributes of the system"
         }
     }
-    
+
     CONFIG_EXAMPLE = {
+        "adapter_name": "my_local_files_adapter",
         "watch_dir": ["/path/to/watch/dir"],
         "buffer_size": 10,
         "wait_before_read": 2,
@@ -42,19 +43,19 @@ class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
             "model": "LocalFilesModel"
         }
     }
-    
+
     RECOMMENDED_TOPIC_FAMILY = "blob"
-    
+
     SELF_UPDATE = True  # This data adapter will update the data by itself in a separate thread.
-    
+
     class _SystemInfo(BaseModel):
         trial_id: str = Field(..., description="Trial ID for the system. No spaces or special characters allowed.")
         name: str = Field(..., description="Name of the system.")
-                
+
         model_config = {
             "extra": "allow"
-        }        
-    
+        }
+
     class SCHEMA(BaseDataAdapter.SCHEMA):
         watch_dir: List[str] = Field(..., description="List of directories to watch for new files.")
         buffer_size: int = Field(..., description="Maximum number of files to buffer before streaming.")
@@ -62,34 +63,34 @@ class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
         system: "_SystemInfo" = Field(..., description="System information including trial ID, name, and other attributes.")
 
     def __init__(self, config: dict = None) -> None:
+        config['trial_id'] = config['system']['trial_id']
         super().__init__(config)
-        self.cfg['trial_id'] = self.cfg['system']['trial_id']
-        
+
         system_config = config['system']
         self.system_name = system_config['name']
-        
+
         self.component_ids.append(self.system_name)
         self._data[self.system_name] = {}
         self.attributes[self.system_name] = system_config
-        
+
         self.buffer_data = []
-        # buffer_data is a list of data dict that has not been staged 
+        # buffer_data is a list of data dict that has not been staged
         # to publish to MQTT yet. LIFO order.
-           
-        # create a observers for the directories    
-        for dir in config['watch_dir']: 
+
+        # create a observers for the directories
+        for dir in config['watch_dir']:
             observer = Observer()
             observer.schedule(self, path=dir, recursive=True)
             observer.start()
-            print(f"Watching directory {dir}")    
-        
+            print(f"Watching directory {dir}")
+
         print("Waiting for LocalFilesDataAdapter to initialize ...")
         time.sleep(self.cfg["wait_before_read"]*2)
         print("LocalFilesDataAdapter initialized.")
-        
-        self.__create_starter_file()        
-        
-    def get_data(self): 
+
+        self.__create_starter_file()
+
+    def get_data(self):
         if len(self.buffer_data) > 0:
             data = self.buffer_data.pop(0)
             self._data[self.system_name] = data
@@ -105,37 +106,37 @@ class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
         """
         if event.is_directory:
             return
-        
+
         print(f"New file created: {event.src_path}")
-        
+
         time.sleep(self.cfg["wait_before_read"])
-        
+
         data = {}
         data["file_name"] = self.__get_event_data(event, 'file_name')
         data["file_type"] = self.__get_event_data(event, 'file_type')
-        data["file_path"] = self.__get_event_data(event, 'file_path')       
+        data["file_path"] = self.__get_event_data(event, 'file_path')
         data["timestamp"] = self.__get_event_data(event, 'timestamp')
         data["file"] = self.__get_event_data(event, 'file')
         data["size"] = self.__get_event_data(event, 'size')
-        
+
         data["trial_id"] = self.cfg["system"]["trial_id"]
         data["system"] = self.cfg["system"]
-        
+
         if len(self.buffer_data) >= self.cfg["buffer_size"]:
             print(f"WARNING: Buffer full. Ignoring file {self.buffer_data[-1]['file_name']}")
             print("Consider increasing buffer size or streaming_rate.")
             self.buffer_data.pop(0)
-            
+
         self.buffer_data.append(data)
         self._notify_observers({self.system_name: data})
-        
+
     def on_modified(self, event: FileSystemEvent) -> None:
         return self.on_created(event)
 
     def update_config(self, config: dict):
         """
         Update the configuration of the data object with the new configuration.
-        
+
         Args:
             config (dict): The new configuration of the data object.
         """
@@ -167,21 +168,21 @@ class LocalFilesDataAdapter(BaseDataAdapter, FileSystemEventHandler):
         elif key == 'size':
             return os.path.getsize(event.src_path)
         else:
-            return None    
+            return None
 
     def __create_starter_file(self):
         target_dir = self.cfg['watch_dir'][0]
         time_now = time.strftime("%Y%m%d-%H%M%S")
         filename = os.path.join(target_dir, f"mfi_ddb_start_{time_now}.txt")
-        
+
         source_info = {}
         source_info['hostname'] = socket.gethostname()
         source_info['os'] = platform.system()
         source_info['fqdn'] = socket.getfqdn()
-        
+
         file_dict = {}
         file_dict['source_info'] = source_info
         file_dict['config'] = self.cfg
-        
+
         with open(filename, "w") as file:
             file.write(yaml.dump(file_dict))

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/mqtt.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/mqtt.py
@@ -126,6 +126,7 @@ class MqttDataAdapter(BaseDataAdapter, _Mqtt):
     }
     
     CONFIG_EXAMPLE = {
+        "adapter_name": "my_mqtt_adapter",
         "mqtt": {
             "broker_address": "mqtt.example.com",
             "broker_port": 1883,

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/mtconnect.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/mtconnect.py
@@ -15,14 +15,14 @@ class _SCHEMA(BaseModel):
         agent_ip: str = Field(..., description="IP address of the MTConnect agent")
         agent_url: str = Field(..., description="URL of the MTConnect agent")
         device_name: str = Field(..., description="Name of the device to be used in the data object")
-        trial_id: str = Field(..., description="Trial ID for the MTConnect device. No spaces or special characters allowed.")    
+        trial_id: str = Field(..., description="Trial ID for the MTConnect device. No spaces or special characters allowed.")
     class SCHEMA(BaseModel):
         mtconnect: "_MTCONNECT" = Field(..., description="Configuration for the MTConnect agent connection")
 
 class MTconnectDataAdapter(BaseDataAdapter):
-    
+
     NAME = "MTConnect"
-    
+
     CONFIG_HELP = {
         "mtconnect": {
             "agent_ip": "IP address of the MTConnect agent",
@@ -31,8 +31,9 @@ class MTconnectDataAdapter(BaseDataAdapter):
             "trial_id": "Trial ID for the MTConnect device. No spaces or special characters allowed.",
         }
     }
-    
+
     CONFIG_EXAMPLE = {
+        "adapter_name": "my_mtconnect_adapter",
         "mtconnect": {
             "agent_ip": "192.168.1.1",
             "agent_url": "http://192.168.1.1:5000",
@@ -40,11 +41,11 @@ class MTconnectDataAdapter(BaseDataAdapter):
             "trial_id": "trial_001"
         }
     }
-    
+
     RECOMMENDED_TOPIC_FAMILY = "historian"
-    
+
     SELF_UPDATE = False
-    
+
     class SCHEMA(BaseDataAdapter.SCHEMA, _SCHEMA.SCHEMA):
         """
         Schema for the MTConnect data adapter configuration.
@@ -52,15 +53,13 @@ class MTconnectDataAdapter(BaseDataAdapter):
         pass
 
     def __init__(self, config: dict):
-        super().__init__()
-        
-        self.cfg = config
-        self.cfg['trial_id'] = self.cfg['mtconnect']['trial_id']
-        
+        config['trial_id'] = config['mtconnect']['trial_id']
+        super().__init__(config)
+
         self.device_name = self.cfg['mtconnect']['device_name']
         # CHECK IF MTCONNECT AGENT IS ACTIVE
         self.__connect()
-        
+
         # POPULATE COMPONENT IDS AND ATTRIBUTES
         # Note: By default, only first device, from the list of MTConnect devices, is used.
         #       If multiple devices exist, specify config['mtconnect']['mtconnect_uuid'] to use a specific device.
@@ -75,9 +74,9 @@ class MTconnectDataAdapter(BaseDataAdapter):
                         break
             else:
                 device_data = device_data[0]
-                
+
         current_time = time.time()
-            
+
         # Populate device attributes
         device_attributes = {}
         device_attributes['trial_id'] = self.cfg['mtconnect']['trial_id']
@@ -103,39 +102,39 @@ class MTconnectDataAdapter(BaseDataAdapter):
                 data_list = [data_list]
             for data_item in data_list:
                 for key in data_item.keys():
-                    self._data[component_id][f'{data_item["@id"]}/{key}'] = str(data_item[key])                
-                    
+                    self._data[component_id][f'{data_item["@id"]}/{key}'] = str(data_item[key])
+
     def get_data(self):
         raw_data = self.__request_agent('current')
         devices = raw_data.MTConnectStreams.Streams.DeviceStream
         device = devices[0] if isinstance(devices, omegaconf.listconfig.ListConfig) else devices
-        
+
         component_stream = device.ComponentStream
         if not isinstance(component_stream, omegaconf.listconfig.ListConfig):
             component_stream = [component_stream]
-            
+
         self.__populate_data(component_stream)
-    
+
     def update_data(self):
         raw_data = self.__request_agent('sample')
         devices = raw_data.MTConnectStreams.Streams.DeviceStream
         device = devices[0] if isinstance(devices, omegaconf.listconfig.ListConfig) else devices
-        
+
         component_stream = device.ComponentStream
         if not isinstance(component_stream, omegaconf.listconfig.ListConfig):
             component_stream = [component_stream]
-        
+
         self.__populate_data(component_stream)
-        
-        
+
+
     def __connect(self):
         # Ping to see if MTConnect agent is active -----------------------------------
         print("Checking if MTConnect agent is active ...")
         ip = self.cfg['mtconnect']['agent_ip']
-        
+
         response = ping(ip)
         timeout = self.cfg['mtconnect'].get('timeout', 5) if 'timeout' in self.cfg['mtconnect'] else 5
-        
+
         start_time = time.time()
         time_elapsed = 0
         while response is None or time_elapsed < timeout:
@@ -143,23 +142,23 @@ class MTconnectDataAdapter(BaseDataAdapter):
             time.sleep(1)
             response = ping(ip)
             time_elapsed = time.time() - start_time
-            
+
         if response is None:
             raise ConnectionError(f"MTConnect agent at {ip} is not responding after {timeout} seconds.")
-        
-        print(f"MTConnect agent at {ip} is active")    
-        
+
+        print(f"MTConnect agent at {ip} is active")
+
     def __request_agent(self, ext: str):
         URL = self.cfg['mtconnect']['agent_url']
         response = requests.get(URL + ext)
         val = xmltodict.parse(response.text, encoding='utf-8')
-        val = OmegaConf.create(val)        
+        val = OmegaConf.create(val)
         return val
-            
+
     def __get_probe_components(self, data, component_data=None):
         if component_data is None:
             component_data = []
-        
+
         if isinstance(data, omegaconf.dictconfig.DictConfig):
             if 'DataItems' in data.keys():
                 component_data.append(data)
@@ -168,16 +167,16 @@ class MTconnectDataAdapter(BaseDataAdapter):
         elif isinstance(data, omegaconf.listconfig.ListConfig):
             for item in data:
                 self.__get_probe_components(item, component_data)
-        
+
         return component_data
 
     def __populate_data(self, raw_data):
-        
+
         current_time = time.time()
-        
+
         for component_data in raw_data:
             component_id = f'{self.device_name}/{component_data["@componentId"]}'
-            
+
             def extract_key_value(data_item, data_item_key):
                 if isinstance(data_item, omegaconf.dictconfig.DictConfig):
                     for key in data_item.keys():
@@ -190,19 +189,19 @@ class MTconnectDataAdapter(BaseDataAdapter):
                             extract_key_value(item, f'{data_item_key}_{i}')
                 else:
                     try:
-                        self._data[component_id][data_item_key] = self.__autotype(data_item)           
+                        self._data[component_id][data_item_key] = self.__autotype(data_item)
                     except KeyError:
                         print("WARNING: KeyError: ", data_item_key, " not found in data buffer for component ", component_id)
                     self.last_updated[component_id] = current_time
-            
+
             for key in component_data.keys():
                 if key in ['Events', 'Samples']:
                     for data_item_list in component_data[key].values():
                         if not isinstance(data_item_list, omegaconf.listconfig.ListConfig):
-                            data_item_list = [data_item_list]                            
+                            data_item_list = [data_item_list]
                         for data_item in data_item_list:
                             data_item_id = data_item['@dataItemId']
-                            extract_key_value(data_item, data_item_id)                                                         
+                            extract_key_value(data_item, data_item_id)
 
     def __autotype(self, value):
         try:

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/ros.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/ros.py
@@ -26,6 +26,7 @@ class RosDataAdapter(BaseDataAdapter):
         "devices": "List of devices to subscribe to. Each device should have a 'namespace' and a list of 'rostopics' to subscribe to. 'attributes' are optional and can be used to set the attributes of the device.",   
     }
     CONFIG_EXAMPLE = {
+        "adapter_name": "my_ros_adapter",
         "trial_id": "trial_001",
         "devices": {
             "device1": {

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/ros2.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/ros2.py
@@ -335,8 +335,8 @@ class Ros2DataAdapter(BaseDataAdapter):
         
     def __del__(self):
         """Destructor to ensure node is properly shut down."""
-        self.shutdown()
-            
+        self.disconnect()
+                    
     def __start_executor(self):
 
         self.executor = self.MultiThreadedExecutor()

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/ros2.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/ros2.py
@@ -26,6 +26,7 @@ class Ros2DataAdapter(BaseDataAdapter):
         "devices": "List of devices to subscribe to. Each device should have a 'namespace' and a list of 'rostopics' to subscribe to. 'attributes' are optional and can be used to set the attributes of the device.",
     }
     CONFIG_EXAMPLE = {
+        "adapter_name": "my_ros2_adapter",
         "trial_id": "trial_001",
         "devices": {
             "device1": {

--- a/mfi_ddb_package/src/mfi_ddb/data_adapters/ros_files.py
+++ b/mfi_ddb_package/src/mfi_ddb/data_adapters/ros_files.py
@@ -52,6 +52,7 @@ class RosFilesDataAdapter(BaseDataAdapter):
         "devices": "List of devices to subscribe to. Each device should have a 'namespace' and a list of 'rostopics' to subscribe to. 'attributes' are optional and can be used to set the attributes of the device.",   
     }
     CONFIG_EXAMPLE = {
+        "adapter_name": "my_ros_files_adapter",
         "trial_id": "trial_001",
         "set_ros_callback": True,
         "devices": {

--- a/mfi_ddb_package/src/mfi_ddb/streamer/streamer.py
+++ b/mfi_ddb_package/src/mfi_ddb/streamer/streamer.py
@@ -34,10 +34,10 @@ class _SCHEMA:
         password: str = Field("", description="Password for MQTT broker authentication")
         tls_enabled: bool = Field(False, description="Enable TLS for MQTT connection (default: False)")
         debug: bool = Field(False, description="Enable debug mode for MQTT client (default: False)")
-        timeout: int = Field(5, description="Timeout in seconds for connecting to the MQTT broker (default: 5)")    
+        timeout: int = Field(5, description="Timeout in seconds for connecting to the MQTT broker (default: 5)")
         enterprise: str = Field(..., description="Enterprise name for MQTT connection")
         site: str = Field("", description="Site name for MQTT connection")
-    
+
     class _USER(BaseModel):
         user_id: str = Field(..., description="User ID associated with the data")
         domain: str = Field(..., description="Domain of the user")
@@ -93,16 +93,16 @@ class Streamer(Observer):
             "tls_enabled": "Enable TLS for MQTT connection (default: False)",
             "debug": "Enable debug mode for MQTT client (default: False)",
             "timeout": "Timeout in seconds for connecting to the MQTT broker (default: 5)"
-        },        
+        },
     }
-    
+
     class SCHEMA(_SCHEMA.SCHEMA):
         pass
-        
+
     def __init__(self, config: dict, data_adp: BaseDataAdapter, stream_on_update:bool = False) -> None:
         super().__init__()
-        
-        
+
+
         # 1. initialize the data adapter and respective topic family client
         # `````````````````````````````````````````````````````````````````````````
         self.cfg = copy.deepcopy(config)
@@ -120,21 +120,21 @@ class Streamer(Observer):
             topic_family_name = data_adp.RECOMMENDED_TOPIC_FAMILY
         else:
             topic_family_name = config['topic_family']
-            
+
         topic_family = globals()[TOPIC_CLIENTS[topic_family_name][1]]()
         self.__client = globals()[TOPIC_CLIENTS[topic_family_name][0]](self.cfg, topic_family)
-        self.__data_adp = data_adp        
+        self.__data_adp = data_adp
 
         self.__data_adp.get_data()
         print("WARNING: Waiting for birth data to be populated in the data adapter for all components...")
         while any(not bool(value) for value in self.__data_adp.data.values()):
             time.sleep(0.1)
             self.__data_adp.get_data()
-        
+
         self.__birth_data = copy.deepcopy(self.__data_adp.data)
-        
+
         print("Birth data populated in the data adapter for all components.")
-        
+
         # 2. initialize the key-value metadata and respective topic family client
         # `````````````````````````````````````````````````````````````````````````
         kv_topic_family = globals()[TOPIC_CLIENTS['kv'][1]]()
@@ -143,9 +143,9 @@ class Streamer(Observer):
         self.__blob_client = globals()[TOPIC_CLIENTS['blob'][0]](copy.deepcopy(config), blob_topic_family)
         self.__kv_birth_payload = {}
         self.__reset_stream()
-        
+
         self.__last_poll_update = 0
-        
+
         if stream_on_update:
             if(self.__data_adp.SELF_UPDATE):
                 self.__data_adp.add_observer(self)
@@ -160,11 +160,11 @@ class Streamer(Observer):
             blob_death_payload = get_blob_json_payload_from_dict(
                 data = kv_death_payload,
                 file_name = f'{trial_id}_metadata_death.json',
-                trial_id = trial_id)        
+                trial_id = trial_id)
 
             self.__kv_client.set_death_payload("metadata", kv_death_payload)
-            self.__blob_client.set_death_payload("metadata", blob_death_payload)            
-            
+            self.__blob_client.set_death_payload("metadata", blob_death_payload)
+
             self.__client.disconnect()
             self.__kv_client.disconnect()
             self.__blob_client.disconnect()
@@ -173,42 +173,42 @@ class Streamer(Observer):
             print("Streamer instance deleted. Bye! \u2764\uFE0F  MFI")
         except Exception as e:
             print(f"Error while disconnecting: {e}")
-        
+
     def reconnect(self, config=None):
         config = self.cfg if config==None else config
         self.__client.disconnect()
-        
+
         wait_time = 1
         print(f"Trying to reinitialize Data Adapter and connect in {wait_time} second...")
         time.sleep(wait_time)
-        
+
         data_adp = self.__data_adp.__class__(self.__data_adp.cfg)
         self.__init__(config, data_adp)
-    
+
     def poll_and_stream_data(self, polling_rate_hz: int = 1):
-        
+
         try:
             polling_rate_hz = int(polling_rate_hz)
         except Exception:
             print(f"WARNING: Invalid polling rate = {polling_rate_hz}. Using 1Hz.")
             polling_rate_hz = 1
-        
+
         if polling_rate_hz <= 0:
             print(f"WARNING: Invalid polling rate = {polling_rate_hz}. Using 1Hz.")
             polling_rate_hz = 1
-        
+
         while (time.time() - self.__last_poll_update) < 1/polling_rate_hz:
-            time.sleep(0.1)            
-        
+            time.sleep(0.1)
+
         self.__data_adp.get_data()
         self.__client.stream_data(self.__data_adp.data)
         self.__data_adp.clear_data_buffer()
-                
+
         self.__last_poll_update = time.time()
-        
+
     def on_data_update(self, data: dict):
         if self.__refresh_birth_data_with_new_keys(data):
-            self.__reset_stream()        
+            self.__reset_stream()
         self.__client.stream_data(data)
         self.__data_adp.clear_data_buffer(list(data.keys()))
 
@@ -228,17 +228,17 @@ class Streamer(Observer):
 
         Side effects:
             Updates the object's stored birth data in-place to include newly discovered keys.
-            
+
         """
         if not data:
             data = self.__data_adp.data
-        
+
         new_key_detected = False
         for key in data.keys():
             if key not in self.__birth_data:
                 print(f"WARNING: New component_id detected in data adapter: {key}.")
                 '''
-                Not updating the birth data structure here as it requires 
+                Not updating the birth data structure here as it requires
                 updating the data adapter attributes as well.
                 If this warning is seen, one of two scenarios is possible:
                 * the data adapter is populating data for an unknown component(s).
@@ -253,9 +253,9 @@ class Streamer(Observer):
                     new_key_detected = True
                 else:
                     self.__birth_data[key][sub_key] = copy.deepcopy(data[key][sub_key])
- 
+
         return new_key_detected
-    
+
     def __reset_stream(self):
         print("Resetting the stream with updated birth data...")
         # 1. reconnect existing clients
@@ -279,29 +279,29 @@ class Streamer(Observer):
                                                              trial_id = trial_id)
         blob_death_payload = get_blob_json_payload_from_dict(data = kv_death_payload,
                                                              file_name = f'{trial_id}_metadata_death.json',
-                                                             trial_id = trial_id)        
+                                                             trial_id = trial_id)
 
         # 3. publish the key-value metadata birth message with initial data
         # ```````````````````````````````````````````````````````````````````````
         self.__kv_client.set_death_payload("metadata", kv_death_payload)
         self.__kv_client.connect(['metadata'])
-        
+
         self.__blob_client.set_death_payload("metadata", blob_death_payload)
         self.__blob_client.connect(['metadata'])
-        
+
         self.__kv_client.stream_data({"metadata": kv_birth_payload})
         self.__blob_client.stream_data({"metadata": blob_birth_payload})
-        
-        # 4. publish the birth message of the data adapter        
+
+        # 4. publish the birth message of the data adapter
         # `````````````````````````````````````````````````````````````````````````
         self.__client.publish_birth(self.__data_adp.attributes, self.__data_adp.data)
-        self.__data_adp.clear_data_buffer()   
-             
+        self.__data_adp.clear_data_buffer()
+
     def __generate_birth_kv_payload(self) -> dict:
-        
+
         sample_data = copy.deepcopy(self.__birth_data)
         sample_data_size = sys.getsizeof(str(sample_data))
-        
+
         # drop keys until the size is less than 32768 bytes
         # since total size of payload <= 65536 bytes
         # ref: error with paho-mqtt: "struct.error: 'H' format requires 0 <= number <= 65535"
@@ -309,7 +309,7 @@ class Streamer(Observer):
             # remove the last key
             sample_data.popitem()
             sample_data_size = sys.getsizeof(str(sample_data))
-        
+
         payload = {
             "schema_version": "mfi-v1.0",
             "msg_type": "birth",
@@ -338,18 +338,18 @@ class Streamer(Observer):
             },
             "broker": {k: v for k, v in self.cfg["mqtt"].items() if k != "password"},
             "data_topics": list(self.__client.get_data_topics())
-        }         
-        
+        }
+
         return payload
-    
+
     def __generate_death_kv_payload(self, birth_payload: dict) -> dict:
         death_payload = copy.deepcopy(birth_payload)
         death_payload["msg_type"] = "death"
-        
-        # Update death time to now if birth time is more than 5 seconds ago, 
-        # otherwise don't update the time to ensure death time is after birth time. 
+
+        # Update death time to now if birth time is more than 5 seconds ago,
+        # otherwise don't update the time to ensure death time is after birth time.
         # This is to handle the case when streaming is not ended cleanly.
         if (datetime.now() - datetime.fromisoformat(birth_payload["time"]["birth"])) > timedelta(seconds=1.0):
             death_payload["time"]["death"] = datetime.now().isoformat()
-    
+
         return death_payload


### PR DESCRIPTION
### Brief Description
> Provide a short, 2-line description of the contribution.

Add essential config like `trial_id` in BaseDataAdapter pydantic SCHEMA, and use that as parent schema for data adapter classes.

### Details

* **describe existing state (e.g., current console output, results, etc.).**
  * Each data adapter has its own schema. It prevents certain uniformity in config across data adapters.  
  * It is expected from each data adapter to include _"trial_id"_ in their config dict. If not included, there is no error, but it might cause downstream issues where applications may want to use it. 

* **steps to verify the enhancement (how to run the new code and observe the improvement).**
  * Use DataAdapterApp or python module (use below to know how to use it) to verify if excluding 'trial_id` gives an error from BaseDataAdapter class. 
```bash
$ python -m mfi_ddb.scripts.stream_data --help
```
  * `ci-checks.yml` should ensure that the data streaming has no errors. 

* **reference relevant README files to understand the new utility**
  * updated data adapter checklist in `mfi_ddb_package/README.md` and `.github/PULL_REQUEST_TEMPLATE/data_adapters.md`

* **additional changes**
  * updated each existing data adapter class to inherit BaseDataAdapter.SCHEMA
  * updated each existing data adapter class to call the BaseDataAdapter class with the config dict properly.

### Potential failure points
> List at least 3 potential failure scenarios or edge cases where the code might break or not perform as expected.

* The CONFIG_HELP and CONFIG_EXAMPLE do not really support inheritance in the sense that the pydantic schema does. 
* The variable `adapter.NAME` is the name of the adapter class, while `adapter.cfg['adapter_name']` is the name assigned by the user for the adapter instance. 


### Potential improvement
> If you had more time and resources, how would you improve the current implementation? Provide at least 1 suggestion for improvement or future work.

* Variables `NAME`, `CONFIG_EXAMPLE`, `CONFIG_HELP`, `RECOMMENDED_TOPIC_FAMILY`, `SELF_UPDATE` are mutable. They are immutable variables. We need to find a way so that access like adapter.NAME is still supported for read, but restricts mutation.
